### PR TITLE
Added HttpStatusCode and FieldName to Error object

### DIFF
--- a/src/FluentResults/Factories/Results.cs
+++ b/src/FluentResults/Factories/Results.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Net;
 
 namespace FluentResults
 {
@@ -37,7 +38,21 @@ namespace FluentResults
             result.WithError(new Error(errorMessage));
             return result;
         }
+        
+        public static Result Fail(string errorCode, string errorMessage)
+        {
+            var result = new Result();
+            result.WithError(new Error(errorCode, errorMessage));
+            return result;
+        }
 
+        public static Result Fail(string errorCode, string errorMessage, HttpStatusCode httpStatusCode)
+        {
+            var result = new Result();
+            result.WithError(new Error(errorCode, errorMessage, httpStatusCode));
+            return result;
+        }
+        
         public static Result<TValue> Ok<TValue>()
         {
             return new Result<TValue>();
@@ -63,7 +78,21 @@ namespace FluentResults
             result.WithError(new Error(errorMessage));
             return result;
         }
-
+        
+        public static Result<TValue> Fail<TValue>(string errorCode, string errorMessage)
+        {
+            var result = new Result<TValue>();
+            result.WithError(new Error(errorCode, errorMessage));
+            return result;
+        }
+        
+        public static Result<TValue> Fail<TValue>(string errorCode, string errorMessage, HttpStatusCode httpStatusCode)
+        {
+            var result = new Result<TValue>();
+            result.WithError(new Error(errorCode, errorMessage, httpStatusCode));
+            return result;
+        }
+        
         public static Result Merge(params ResultBase[] results)
         {
             return ResultHelper.Merge<Result>(results);

--- a/src/FluentResults/Factories/Results.cs
+++ b/src/FluentResults/Factories/Results.cs
@@ -3,131 +3,131 @@ using System.Net;
 
 namespace FluentResults
 {
-    public static class Results
-    {
-        internal static ResultSettings Settings { get; set; }
+	public static class Results
+	{
+		internal static ResultSettings Settings { get; set; }
 
-        static Results()
-        {
-            Settings = new ResultSettingsBuilder().Build();
-        }
+		static Results()
+		{
+			Settings = new ResultSettingsBuilder().Build();
+		}
 
-        public static void Setup(Action<ResultSettingsBuilder> setupFunc)
-        {
-            var settingsBuilder = new ResultSettingsBuilder();
-            setupFunc(settingsBuilder);
+		public static void Setup(Action<ResultSettingsBuilder> setupFunc)
+		{
+			var settingsBuilder = new ResultSettingsBuilder();
+			setupFunc(settingsBuilder);
 
-            Settings = settingsBuilder.Build();
-        }
+			Settings = settingsBuilder.Build();
+		}
 
-        public static Result Ok()
-        {
-            return new Result();
-        }
-        
-        public static Result Fail(Error error)
-        {
-            var result = new Result();
-            result.WithError(error);
-            return result;
-        }
+		public static Result Ok()
+		{
+			return new Result();
+		}
 
-        public static Result Fail(string errorMessage)
-        {
-            var result = new Result();
-            result.WithError(new Error(errorMessage));
-            return result;
-        }
-        
-        public static Result Fail(string errorCode, string errorMessage)
-        {
-            var result = new Result();
-            result.WithError(new Error(errorCode, errorMessage));
-            return result;
-        }
+		public static Result Fail(Error error)
+		{
+			var result = new Result();
+			result.WithError(error);
+			return result;
+		}
 
-        public static Result Fail(string errorCode, string errorMessage, HttpStatusCode httpStatusCode)
-        {
-            var result = new Result();
-            result.WithError(new Error(errorCode, errorMessage, httpStatusCode));
-            return result;
-        }
-        
-        public static Result<TValue> Ok<TValue>()
-        {
-            return new Result<TValue>();
-        }
+		public static Result Fail(string errorMessage)
+		{
+			var result = new Result();
+			result.WithError(new Error(errorMessage));
+			return result;
+		}
 
-        public static Result<TValue> Ok<TValue>(TValue value)
-        {
-            var result = new Result<TValue>();
-            result.WithValue(value);
-            return result;
-        }
+		public static Result Fail(string errorCode, string errorMessage)
+		{
+			var result = new Result();
+			result.WithError(new Error(errorCode, errorMessage));
+			return result;
+		}
+		
+		public static Result Fail(HttpStatusCode httpStatusCode)
+		{
+			var result = new Result();
+			result.WithHttpStatusCode(httpStatusCode);
+			return result;
+		}
 
-        public static Result<TValue> Fail<TValue>(Error error)
-        {
-            var result = new Result<TValue>();
-            result.WithError(error);
-            return result;
-        }
+		public static Result<TValue> Ok<TValue>()
+		{
+			return new Result<TValue>();
+		}
 
-        public static Result<TValue> Fail<TValue>(string errorMessage)
-        {
-            var result = new Result<TValue>();
-            result.WithError(new Error(errorMessage));
-            return result;
-        }
-        
-        public static Result<TValue> Fail<TValue>(string errorCode, string errorMessage)
-        {
-            var result = new Result<TValue>();
-            result.WithError(new Error(errorCode, errorMessage));
-            return result;
-        }
-        
-        public static Result<TValue> Fail<TValue>(string errorCode, string errorMessage, HttpStatusCode httpStatusCode)
-        {
-            var result = new Result<TValue>();
-            result.WithError(new Error(errorCode, errorMessage, httpStatusCode));
-            return result;
-        }
-        
-        public static Result Merge(params ResultBase[] results)
-        {
-            return ResultHelper.Merge<Result>(results);
-        }
+		public static Result<TValue> Ok<TValue>(TValue value)
+		{
+			var result = new Result<TValue>();
+			result.WithValue(value);
+			return result;
+		}
 
-        public static Result<TValue> Merge<TValue>(params ResultBase[] results)
-        {
-            return ResultHelper.Merge<Result<TValue>>(results);
-        }
-    }
+		public static Result<TValue> Fail<TValue>(Error error)
+		{
+			var result = new Result<TValue>();
+			result.WithError(error);
+			return result;
+		}
 
-    public static class Results<TResult> where TResult : ResultBase<TResult>, new()
-    {
-        public static TResult Ok()
-        {
-            return new TResult();
-        }
-        
-        public static TResult Fail(Error error)
-        {
-            var result = new TResult();
-            result.WithError(error);
-            return result;
-        }
+		public static Result<TValue> Fail<TValue>(string errorMessage)
+		{
+			var result = new Result<TValue>();
+			result.WithError(new Error(errorMessage));
+			return result;
+		}
 
-        public static TResult Fail(string errorMessage)
-        {
-            var result = new TResult();
-            result.WithError(new Error(errorMessage));
-            return result;
-        }
+		public static Result<TValue> Fail<TValue>(string errorCode, string errorMessage)
+		{
+			var result = new Result<TValue>();
+			result.WithError(new Error(errorCode, errorMessage));
+			return result;
+		}
 
-        public static TResult Merge(params ResultBase[] results)
-        {
-            return ResultHelper.Merge<TResult>(results);
-        }
-    }
+		public static Result<TValue> Fail<TValue>(HttpStatusCode httpStatusCode)
+		{
+			var result = new Result<TValue>();
+			result.WithHttpStatusCode(httpStatusCode);
+			return result;
+		}
+
+		public static Result Merge(params ResultBase[] results)
+		{
+			return ResultHelper.Merge<Result>(results);
+		}
+
+		public static Result<TValue> Merge<TValue>(params ResultBase[] results)
+		{
+			return ResultHelper.Merge<Result<TValue>>(results);
+		}
+	}
+
+	public static class Results<TResult> where TResult : ResultBase<TResult>, new()
+	{
+		public static TResult Ok()
+		{
+			return new TResult();
+		}
+
+		public static TResult Fail(Error error)
+		{
+			var result = new TResult();
+			result.WithError(error);
+			return result;
+		}
+
+		public static TResult Fail(string errorMessage)
+		{
+			var result = new TResult();
+			result.WithError(new Error(errorMessage));
+			return result;
+		}
+
+		public static TResult Merge(params ResultBase[] results)
+		{
+			return ResultHelper.Merge<TResult>(results);
+		}
+	}
 }

--- a/src/FluentResults/FluentResults.csproj
+++ b/src/FluentResults/FluentResults.csproj
@@ -1,14 +1,32 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;net45</TargetFrameworks>
-     <PackageId>FluentResults</PackageId>
-     <PackageVersion>0.7.1</PackageVersion>
-     <Authors>Michael Altmann</Authors>
-     <Description>A lightweight Result object implementation for .NET</Description>
-     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-     <PackageReleaseNotes>First release</PackageReleaseNotes>
-     <Copyright>Copyright 2017 (c) Michael Altmann. All rights reserved.</Copyright>
-     <PackageTags>Results exception error handling</PackageTags>
-     <ProjectUrl>https://github.com/altmann/FluentResults</ProjectUrl>
+    <PackageId>FluentResults</PackageId>
+    <PackageVersion>0.7.1</PackageVersion>
+    <Authors>Michael Altmann</Authors>
+    <Description>A lightweight Result object implementation for .NET</Description>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <PackageReleaseNotes>First release</PackageReleaseNotes>
+    <Copyright>Copyright 2017 (c) Michael Altmann. All rights reserved.</Copyright>
+    <PackageTags>Results exception error handling</PackageTags>
+    <ProjectUrl>https://github.com/altmann/FluentResults</ProjectUrl>
   </PropertyGroup>
+  <ItemGroup>
+    <Compile Remove="Playground.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Remove="MyValueResult.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Remove="Custom\MyError.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Remove="Custom\**" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Remove="Custom\**" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Remove="Custom\**" />
+  </ItemGroup>
 </Project>

--- a/src/FluentResults/Reasons/Error.cs
+++ b/src/FluentResults/Reasons/Error.cs
@@ -8,8 +8,8 @@ namespace FluentResults
     public class Error : Reason
     {
         public string ErrorCode { get; protected set; }
+        public string FieldName { get; protected set; }
         public List<Error> Reasons { get; }
-        public HttpStatusCode HttpStatusCode { get; protected set; }
 
         public Error()
         {
@@ -28,14 +28,6 @@ namespace FluentResults
         {
             Message = message;
             ErrorCode = errorCode;
-        }
-        
-        public Error(string errorCode, string message, HttpStatusCode httpStatusCode)
-            : this()
-        {
-            ErrorCode = errorCode;
-            Message = message;
-            HttpStatusCode = httpStatusCode;
         }
         
         public Error(string message, Error causedBy)
@@ -62,6 +54,12 @@ namespace FluentResults
             return this;
         }
 
+        public Error WithFieldName(string fieldName)
+        {
+            FieldName = fieldName;
+            return this;
+        }
+        
         public Error WithTag(string tag)
         {
             Tags.Add(tag);
@@ -71,12 +69,6 @@ namespace FluentResults
         public Error WithTags(params string[] tags)
         {
             Tags.AddRange(tags);
-            return this;
-        }
-
-        public Error WithHttpStatusCode(HttpStatusCode httpStatusCode)
-        {
-            HttpStatusCode = httpStatusCode;
             return this;
         }
 
@@ -102,6 +94,7 @@ namespace FluentResults
         {
             return base.GetReasonStringBuilder()
                 .WithInfo(nameof(ErrorCode), ErrorCode)
+                .WithInfo(nameof(FieldName), FieldName)
                 .WithInfo(nameof(Reasons), ReasonFormat.ErrorReasonsToString(Reasons));
         }
     }

--- a/src/FluentResults/Reasons/Error.cs
+++ b/src/FluentResults/Reasons/Error.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 
 namespace FluentResults
 {
@@ -8,6 +9,7 @@ namespace FluentResults
     {
         public string ErrorCode { get; protected set; }
         public List<Error> Reasons { get; }
+        public HttpStatusCode HttpStatusCode { get; protected set; }
 
         public Error()
         {
@@ -21,6 +23,21 @@ namespace FluentResults
             Message = message;
         }
 
+        public Error(string errorCode, string message)
+            : this()
+        {
+            Message = message;
+            ErrorCode = errorCode;
+        }
+        
+        public Error(string errorCode, string message, HttpStatusCode httpStatusCode)
+            : this()
+        {
+            ErrorCode = errorCode;
+            Message = message;
+            HttpStatusCode = httpStatusCode;
+        }
+        
         public Error(string message, Error causedBy)
             : this(message)
         {
@@ -54,6 +71,12 @@ namespace FluentResults
         public Error WithTags(params string[] tags)
         {
             Tags.AddRange(tags);
+            return this;
+        }
+
+        public Error WithHttpStatusCode(HttpStatusCode httpStatusCode)
+        {
+            HttpStatusCode = httpStatusCode;
             return this;
         }
 

--- a/src/FluentResults/Results/ResultBase.cs
+++ b/src/FluentResults/Results/ResultBase.cs
@@ -1,103 +1,112 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 
 namespace FluentResults
 {
-    public abstract class ResultBase
-    {
-        public bool IsFailed => Reasons.OfType<Error>().Any();
-        public bool IsSuccess => !IsFailed;
+	public abstract class ResultBase
+	{
+		public bool IsFailed => Reasons.OfType<Error>().Any();
+		public bool IsSuccess => !IsFailed;
 
-        public List<Reason> Reasons { get; }
-        public List<Error> Errors => Reasons.OfType<Error>().ToList();
-        public List<Success> Successes => Reasons.OfType<Success>().ToList();
+		public List<Reason> Reasons { get; }
+		public List<Error> Errors => Reasons.OfType<Error>().ToList();
+		public List<Success> Successes => Reasons.OfType<Success>().ToList();
+		public HttpStatusCode HttpStatusCode { get; set; }
 
-        protected ResultBase()
-        {
-            Reasons = new List<Reason>();
-        }
-    }
+		protected ResultBase()
+		{
+			Reasons = new List<Reason>();
+			HttpStatusCode = HttpStatusCode.OK;
+		}
+	}
 
-    public abstract class ResultBase<TResult> : ResultBase
-        where TResult : ResultBase<TResult>
-    {
-        public TResult WithReason(Reason reason)
-        {
-            Reasons.Add(reason);
-            return (TResult)this;
-        }
+	public abstract class ResultBase<TResult> : ResultBase
+		where TResult : ResultBase<TResult>
+	{
+		public TResult WithReason(Reason reason)
+		{
+			Reasons.Add(reason);
+			return (TResult) this;
+		}
 
-        public TResult WithError(string errorMessage)
-        {
-            return WithError(new Error(errorMessage));
-        }
+		public TResult WithError(string errorMessage)
+		{
+			return WithError(new Error(errorMessage));
+		}
 
-        public TResult WithError(Error error)
-        {
-            return WithReason(error);
-        }
+		public TResult WithError(Error error)
+		{
+			return WithReason(error);
+		}
 
-        public TResult WithError<TError>()
-            where TError : Error, new()
-        {
-            return WithError(new TError());
-        }
+		public TResult WithError<TError>()
+			where TError : Error, new()
+		{
+			return WithError(new TError());
+		}
 
-        public TResult WithSuccess(string successMessage)
-        {
-            return WithSuccess(new Success(successMessage));
-        }
+		public TResult WithSuccess(string successMessage)
+		{
+			return WithSuccess(new Success(successMessage));
+		}
 
-        public TResult WithSuccess(Success success)
-        {
-            return WithReason(success);
-        }
+		public TResult WithSuccess(Success success)
+		{
+			return WithReason(success);
+		}
 
-        public TResult WithSuccess<TSuccess>()
-            where TSuccess : Success, new()
-        {
-            return WithSuccess(new TSuccess());
-        }
-        
-        public TResult With(Action<TResult> setProperty)
-        {
-            setProperty((TResult)this);
-            return (TResult)this;
-        }
+		public TResult WithSuccess<TSuccess>()
+			where TSuccess : Success, new()
+		{
+			return WithSuccess(new TSuccess());
+		}
 
-        public Result<TNewValue> ConvertToResultWithValueType<TNewValue>()
-        {
-            return ResultHelper.Merge<Result<TNewValue>>(this);
-        }
+		public TResult WithHttpStatusCode(HttpStatusCode httpStatusCode)
+		{
+			HttpStatusCode = httpStatusCode;
+			return (TResult) this;
+		}
 
-        public TNewResult ConvertToResultOfType<TNewResult>()
-            where TNewResult : ResultBase<TNewResult>, new()
-        {
-            return ResultHelper.Merge<TNewResult>(this);
-        }
+		public TResult With(Action<TResult> setProperty)
+		{
+			setProperty((TResult) this);
+			return (TResult) this;
+		}
 
-        public TResult Log()
-        {
-            return Log(string.Empty);
-        }
+		public Result<TNewValue> ConvertToResultWithValueType<TNewValue>()
+		{
+			return ResultHelper.Merge<Result<TNewValue>>(this);
+		}
 
-        public TResult Log(string context)
-        {
-            var logger = Results.Settings.Logger;
+		public TNewResult ConvertToResultOfType<TNewResult>()
+			where TNewResult : ResultBase<TNewResult>, new()
+		{
+			return ResultHelper.Merge<TNewResult>(this);
+		}
 
-            logger.Log(context, this);
+		public TResult Log()
+		{
+			return Log(string.Empty);
+		}
 
-            return (TResult)this;
-        }
+		public TResult Log(string context)
+		{
+			var logger = Results.Settings.Logger;
 
-        public override string ToString()
-        {
-            var reasonsString = Reasons.Any()
-                ? $", Reasons='{ReasonFormat.ReasonsToString(Reasons)}'"
-                : string.Empty;
+			logger.Log(context, this);
 
-            return $"Result: IsSuccess='{IsSuccess}'{reasonsString}";
-        }
-    }
+			return (TResult) this;
+		}
+
+		public override string ToString()
+		{
+			var reasonsString = Reasons.Any()
+				? $", Reasons='{ReasonFormat.ReasonsToString(Reasons)}'"
+				: string.Empty;
+
+			return $"Result: IsSuccess='{IsSuccess}'{reasonsString}";
+		}
+	}
 }


### PR DESCRIPTION
I am using this library with REST services. In that case it's usefull to add an HttpStatusCode to the Result; that way you can indicate for example a OK, Created in case of Success, or in case or Failure for example a NotFound.
I also added a FieldName property to the Error object. In REST scenarios it's usefull to have the fieldName as a separate property to indicate a validation error for example.
Free to accept the PR.