### PR TITLE
Include a netstandard2.0 target

### DIFF
--- a/src/FluentResults/FluentResults.csproj
+++ b/src/FluentResults/FluentResults.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.1;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.1;netstandard2.0;net45</TargetFrameworks>
     <PackageId>FluentResults</PackageId>
     <PackageVersion>1.1.1.0</PackageVersion>
     <Authors>Michael Altmann</Authors>


### PR DESCRIPTION
Hi @altmann, thanks for the package! 

I've added a netstandard 2.0 target to create a smaller package dependency graph. All platforms supporting .NET Standard 2.0 will use the netstandard2.0 target and benefit from having a smaller package graph while older platforms will still work and fall back to using the netstandard1.1 target.

Please see https://docs.microsoft.com/en-us/dotnet/standard/library-guidance/cross-platform-targeting#net-standard for more details if required.

I didn't increase your `<PackageVersion>` because I wasn't sure if you felt this would be a minor or patch version increase. If you let me know what version you would like, I can update my PR.