### PR TITLE
Returning AndWhichConstraint from FluentAssertion extensions

### DIFF
--- a/src/FluentResults.Extensions.FluentAssertions/ResultAssertions.cs
+++ b/src/FluentResults.Extensions.FluentAssertions/ResultAssertions.cs
@@ -19,7 +19,7 @@ namespace FluentResults.Extensions.FluentAssertions
 
         protected override string Identifier => nameof(Result);
 
-        public AndConstraint<ResultAssertions> BeFailure(string because = "", params object[] becauseArgs)
+        public AndWhichConstraint<ResultAssertions, Result> BeFailure(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
@@ -27,10 +27,10 @@ namespace FluentResults.Extensions.FluentAssertions
                 .ForCondition(isFailed => isFailed)
                 .FailWith("Expected result be failed, but is success");
 
-            return new AndConstraint<ResultAssertions>(this);
+            return new AndWhichConstraint<ResultAssertions, Result>(this, Subject);
         }
 
-        public AndConstraint<ResultAssertions> BeSuccess(string because = "", params object[] becauseArgs)
+        public AndWhichConstraint<ResultAssertions, Result> BeSuccess(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
@@ -38,7 +38,7 @@ namespace FluentResults.Extensions.FluentAssertions
                 .ForCondition(isSuccess => isSuccess)
                 .FailWith("Expected result be success, but is failed because of '{0}'", Subject.Errors);
 
-            return new AndConstraint<ResultAssertions>(this);
+            return new AndWhichConstraint<ResultAssertions, Result>(this, Subject);
         }
 
         public AndConstraint<ResultAssertions> Satisfy(Action<Result> action)
@@ -63,7 +63,7 @@ namespace FluentResults.Extensions.FluentAssertions
 
         protected override string Identifier => nameof(Result);
 
-        public AndConstraint<ResultAssertions<T>> BeFailure(string because = "", params object[] becauseArgs)
+        public AndWhichConstraint<ResultAssertions<T>, Result<T>> BeFailure(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
@@ -71,10 +71,10 @@ namespace FluentResults.Extensions.FluentAssertions
                 .ForCondition(actualIsFailed => actualIsFailed)
                 .FailWith("Expected result be failed, but is success");
 
-            return new AndConstraint<ResultAssertions<T>>(this);
+            return new AndWhichConstraint<ResultAssertions<T>, Result<T>>(this, Subject);
         }
 
-        public AndConstraint<ResultAssertions<T>> BeSuccess(string because = "", params object[] becauseArgs)
+        public AndWhichConstraint<ResultAssertions<T>, Result<T>> BeSuccess(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
@@ -82,7 +82,7 @@ namespace FluentResults.Extensions.FluentAssertions
                 .ForCondition(actualIsSuccess => actualIsSuccess)
                 .FailWith("Expected result be success, but is failed because of '{0}'", Subject.Errors);
 
-            return new AndConstraint<ResultAssertions<T>>(this);
+            return new AndWhichConstraint<ResultAssertions<T>, Result<T>>(this, Subject);
         }
 
         public AndConstraint<ResultAssertions<T>> HaveValue(T expectedValue, string because = "", params object[] becauseArgs)


### PR DESCRIPTION
Previously with just `AndConstraint`, to chain anything more complex you had to route back through the `Subject` property, e.g.,

```result.Should().BeSuccess().And.Subject.Value.Should().BeEquivalentTo(expectedValues)```

The `AndWhichContraint` simplifies this slightly as it gives direct access back to the original subject through the `Which` property.  It allows the above statement to be simplified slightly to:

```result.Should().BeSuccess().Which.Value.Should().BeEquivalentTo(expectedValues)```

It's a relatively minor change, but it allows the sentence to flow nicer.