### PR TITLE
Accepting of a TNewValue for ToResult

### DIFF
--- a/src/FluentResults.Test/ResultWithValueTests.cs
+++ b/src/FluentResults.Test/ResultWithValueTests.cs
@@ -157,7 +157,7 @@ namespace FluentResults.Test
         }
 
         [Fact]
-        public void ToResult_ToAntotherValueTypeWithOkResultAndConverter_ReturnFailedResult()
+        public void ToResult_ToAntotherValueTypeWithOkResultAndConverter_ReturnSuccessResult()
         {
             var valueResult = Result.Ok(4);
 

--- a/src/FluentResults.Test/ResultWithoutValueTests.cs
+++ b/src/FluentResults.Test/ResultWithoutValueTests.cs
@@ -93,6 +93,32 @@ namespace FluentResults.Test
         }
 
         [Fact]
+        public void ToResult_WithOkResultAndValue_ReturnSuccessResult()
+        {
+            var valueResult = Result.Ok();
+
+            // Act
+            var result = valueResult.ToResult<float>(2.5f);
+
+            // Assert
+            result.IsSuccess.Should().BeTrue();
+            result.Value.Should().Be(2.5f);
+        }
+
+        [Fact]
+        public void ToResult_WithOkResultWithoutValue_ReturnSuccessResult()
+        {
+            var valueResult = Result.Ok();
+
+            // Act
+            var result = valueResult.ToResult<bool>();
+
+            // Assert
+            result.IsSuccess.Should().BeTrue();
+            result.Value.Should().Be(default);
+        }
+
+        [Fact]
         public void ImplicitCastOperator_ReturnFailedValueResult()
         {
             var result = Result.Fail("First error message");

--- a/src/FluentResults/Results/Result.cs
+++ b/src/FluentResults/Results/Result.cs
@@ -8,9 +8,10 @@ namespace FluentResults
         public Result()
         { }
 
-        public Result<TNewValue> ToResult<TNewValue>()
+        public Result<TNewValue> ToResult<TNewValue>(TNewValue newValue = default)
         {
             return new Result<TNewValue>()
+                .WithValue(IsFailed ? default : newValue)
                 .WithReasons(Reasons);
         }
     }


### PR DESCRIPTION
Changes described in #86.  
Additional parameter added to ToResult to allow specifying the value to use when transforming a result.  Defaulted to `default` to retain the existing functionality and API.

This method only applies to the non-generic `Result` type.  If applied to the generic `Result<T>` type, it would be ignoring the existing value which seems like bad practice.

Also corrected the name of the `ToResult_ToAntotherValueTypeWithOkResultAndConverter_ReturnFailedResult` test as it was incorrectly named based on the assert condition.