### PR TITLE
Typed Log context

### DIFF
--- a/src/FluentResults.Test/Mocks/LoggingMock.cs
+++ b/src/FluentResults.Test/Mocks/LoggingMock.cs
@@ -8,6 +8,12 @@
             LoggedResult = result;
         }
 
+        public void Log<TContext>(ResultBase result)
+        {
+            LoggedContext = typeof(TContext).ToString();
+            LoggedResult = result;
+        }
+
         public string LoggedContext { get; private set; }
         public ResultBase LoggedResult { get; private set; }
     }

--- a/src/FluentResults.Test/ResultLoggingTests.cs
+++ b/src/FluentResults.Test/ResultLoggingTests.cs
@@ -23,5 +23,42 @@ namespace FluentResults.Test
             logger.LoggedContext.Should().Be(string.Empty);
             logger.LoggedResult.Should().NotBeNull();
         }
+
+        [Fact]
+        public void LogOkResultWithContext_EmptySuccess()
+        {
+            // Arrange
+            var context = "context";
+            var logger = new LoggingMock();
+            Result.Setup(cfg => {
+                cfg.Logger = logger;
+            });
+
+            // Act
+            Result.Ok()
+                .Log(context);
+
+            // Assert
+            logger.LoggedContext.Should().Be(context);
+            logger.LoggedResult.Should().NotBeNull();
+        }
+
+        [Fact]
+        public void LogOkResultWithTypedContext_EmptySuccess()
+        {
+            // Arrange
+            var logger = new LoggingMock();
+            Result.Setup(cfg => {
+                cfg.Logger = logger;
+            });
+
+            // Act
+            Result.Ok()
+                .Log<Result>();
+
+            // Assert
+            logger.LoggedContext.Should().Be(typeof(Result).ToString());
+            logger.LoggedResult.Should().NotBeNull();
+        }
     }
 }

--- a/src/FluentResults/Logging/DefaultLogger.cs
+++ b/src/FluentResults/Logging/DefaultLogger.cs
@@ -5,7 +5,12 @@ namespace FluentResults
     {
         public void Log(string context, ResultBase result)
         {
-            
+
+        }
+
+        public void Log<TContext>(ResultBase result)
+        {
+
         }
     }
 }

--- a/src/FluentResults/Logging/IResultLogger.cs
+++ b/src/FluentResults/Logging/IResultLogger.cs
@@ -4,5 +4,6 @@ namespace FluentResults
     public interface IResultLogger
     {
         void Log(string context, ResultBase result);
+        void Log<TContext>(ResultBase result);
     }
 }

--- a/src/FluentResults/Results/ResultBase.cs
+++ b/src/FluentResults/Results/ResultBase.cs
@@ -199,6 +199,19 @@ namespace FluentResults
             return (TResult)this;
         }
 
+        /// <summary>
+        /// Log the result with a typed context. Configure the logger via Result.Setup(..)
+        /// </summary>
+        public TResult Log<TContext>()
+        {
+            var logger = Result.Settings.Logger;
+
+            logger.Log<TContext>(this);
+
+            return (TResult)this;
+        }
+
+
         public override string ToString()
         {
             var reasonsString = Reasons.Any()


### PR DESCRIPTION
I would like to suggest the addition of a typed context log method. This way, we can pass the context as type, not as string and without resorting to crazy reflections. This would be helpful when using third-party loggers, like Serilog, where we can do something like this in `IResultsLogger` implementation:
```csharp
Serilog.Log.ForContext<TContext>().Information("Result success");
```
Thanks for this amazing project!