### PR TITLE
Support FluentAssertions >=6.0.0

### DIFF
--- a/src/FluentResults.Extensions.FluentAssertions/ErrorListValueFormatter.cs
+++ b/src/FluentResults.Extensions.FluentAssertions/ErrorListValueFormatter.cs
@@ -11,11 +11,10 @@ namespace FluentResults.Extensions.FluentAssertions
             return value is List<Error>;
         }
 
-        public string Format(object value, FormattingContext context, FormatChild formatChild)
+        public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
         {
             var errors = (IEnumerable<Error>)value;
-
-            return string.Join("; ", errors.Select(error => error.Message));
+            formattedGraph.AddFragment(string.Join("; ", errors.Select(error => error.Message)));
         }
     }
 }

--- a/src/FluentResults.Extensions.FluentAssertions/FluentResults.Extensions.FluentAssertions.csproj
+++ b/src/FluentResults.Extensions.FluentAssertions/FluentResults.Extensions.FluentAssertions.csproj
@@ -26,7 +26,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="FluentAssertions" Version="6.1.0" />
     <PackageReference Include="FluentResults" Version="2.5.0" />
   </ItemGroup>
 

--- a/src/FluentResults.Extensions.FluentAssertions/ResultAssertions.cs
+++ b/src/FluentResults.Extensions.FluentAssertions/ResultAssertions.cs
@@ -12,9 +12,10 @@ namespace FluentResults.Extensions.FluentAssertions
             ResultFormatters.Register();
         }
 
-        public ResultAssertions(Result instance)
+        public ResultAssertions(Result subject)
+            : base(subject)
         {
-            Subject = instance;
+
         }
 
         protected override string Identifier => nameof(Result);
@@ -56,9 +57,9 @@ namespace FluentResults.Extensions.FluentAssertions
             ResultFormatters.Register();
         }
 
-        public ResultAssertions(Result<T> instance)
+        public ResultAssertions(Result<T> subject)
+            : base(subject)
         {
-            Subject = instance;
         }
 
         protected override string Identifier => nameof(Result);

--- a/src/FluentResults.Test/FluentResults.Test.csproj
+++ b/src/FluentResults.Test/FluentResults.Test.csproj
@@ -12,7 +12,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="coverlet.collector" Version="1.2.0" />
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="FluentAssertions" Version="6.1.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Hi!

In FluentAssertions v6 there are some breaking changes which affected this project.

> Changed ReferenceTypeAssertions.Subject to be readonly

https://github.com/fluentassertions/fluentassertions/pull/1229

>Formatter.ToString() and IValueFormatter now work with a FormattingOptions object that wraps the UseLineBreaks option 

https://github.com/fluentassertions/fluentassertions/pull/1469

> Dropped support for .NET Framework 4.5, .NET Standard 1.3 and 1.6

I've noticed that you already retargeted platorms on this branch so I've made PR to this one instead of master.

Best regards,
Mateusz