### PR TITLE
Add additional FluentAssertion methods for asserting reasons.

### DIFF
--- a/src/FluentResults.Extensions.FluentAssertions.Test/ResultTests/HaveReasonTests.cs
+++ b/src/FluentResults.Extensions.FluentAssertions.Test/ResultTests/HaveReasonTests.cs
@@ -1,0 +1,80 @@
+﻿using FluentAssertions;
+using System;
+using Xunit;
+using Xunit.Sdk;
+
+namespace FluentResults.Extensions.FluentAssertions.Test.ResultTests
+{
+    public class HaveReasonTests
+    {
+        [Theory]
+        [InlineData("Error 1")]
+        [InlineData("Error")]
+        public void A_result_with_expected_reason_throw_no_exception(string expectedError)
+        {
+            var failedResult = Result.Fail("Error 1");
+
+            Action action = () => failedResult.Should().BeFailure().And.HaveReason(expectedError);
+
+            action.Should().NotThrow();
+        }
+
+        [Fact]
+        public void A_result_without_expected_reason_throw_a_exception()
+        {
+            var successResult = Result.Fail("Error 2");
+
+            Action action = () => successResult.Should().BeFailure().And.HaveReason("Error 1");
+
+            action.Should()
+                .Throw<XunitException>()
+                .WithMessage("Expected result to contain reason with message containing \"Error 1\", but found reasons '{Error with Message='Error 2'}'");
+        }
+
+        [Theory]
+        [InlineData("Error 1")]
+        [InlineData("Error")]
+        public void A_result_with_expected_reason_of_type_throw_no_exception(string expectedError)
+        {
+            var successResult = Result.Fail(new SomeReason("Error 1"));
+
+            Action action = () => successResult.Should().BeFailure().And.HaveReason<SomeReason>(expectedError);
+
+            action.Should().NotThrow();
+        }
+
+        [Fact]
+        public void A_result_without_expected_reason_of_type_throw_a_exception()
+        {
+            var successResult = Result.Fail("Error 1");
+
+            Action action = () => successResult.Should().BeFailure().And.HaveReason<SomeReason>("Error 1");
+
+            action.Should()
+                .Throw<XunitException>()
+                .WithMessage("Expected result to contain reason of type \"SomeReason\" with message containing \"Error 1\", but found reasons '{Error with Message='Error 1'}'");
+        }
+
+        [Fact]
+        public void A_result_with_expected_reason_object_throw_no_exception()
+        {
+            var successResult = Result.Fail("Error 1");
+
+            Action action = () => successResult.Should().BeFailure().And.HaveReason(new Error("Error 1"));
+
+            action.Should().NotThrow();
+        }
+
+        [Fact]
+        public void A_result_without_expected_reason_object_throw_a_exception()
+        {
+            var successResult = Result.Fail("Error 1");
+
+            Action action = () => successResult.Should().BeFailure().And.HaveReason(new Error("Error 2"));
+
+            action.Should()
+                .Throw<XunitException>()
+                .WithMessage("Expected Subject.Reasons {Error with Message='Error 1'} to contain equivalent of Error with Message='Error 2'*");
+        }
+    }
+}

--- a/src/FluentResults.Extensions.FluentAssertions.Test/SomeReason.cs
+++ b/src/FluentResults.Extensions.FluentAssertions.Test/SomeReason.cs
@@ -1,0 +1,10 @@
+﻿namespace FluentResults.Extensions.FluentAssertions.Test
+{
+    internal class SomeReason : Error
+    {
+        public SomeReason(string message) : base(message)
+        {
+
+        }
+    }
+}

--- a/src/FluentResults.Extensions.FluentAssertions.Test/ValueResultTests/HaveReasonTests.cs
+++ b/src/FluentResults.Extensions.FluentAssertions.Test/ValueResultTests/HaveReasonTests.cs
@@ -1,0 +1,80 @@
+﻿using FluentAssertions;
+using System;
+using Xunit;
+using Xunit.Sdk;
+
+namespace FluentResults.Extensions.FluentAssertions.Test.ValueResultTests
+{
+    public class HaveReasonTests
+    {
+        [Theory]
+        [InlineData("Error 1")]
+        [InlineData("Error")]
+        public void A_result_with_expected_reason_throw_no_exception(string expectedError)
+        {
+            var failedResult = Result.Fail<int>("Error 1");
+
+            Action action = () => failedResult.Should().BeFailure().And.HaveReason(expectedError);
+
+            action.Should().NotThrow();
+        }
+
+        [Fact]
+        public void A_result_without_expected_reason_throw_a_exception()
+        {
+            var successResult = Result.Fail<int>("Error 2");
+
+            Action action = () => successResult.Should().BeFailure().And.HaveReason("Error 1");
+
+            action.Should()
+                .Throw<XunitException>()
+                .WithMessage("Expected result to contain reason with message containing \"Error 1\", but found reasons '{Error with Message='Error 2'}'");
+        }
+
+        [Theory]
+        [InlineData("Error 1")]
+        [InlineData("Error")]
+        public void A_result_with_expected_reason_of_type_throw_no_exception(string expectedError)
+        {
+            var successResult = Result.Fail<int>(new SomeReason("Error 1"));
+
+            Action action = () => successResult.Should().BeFailure().And.HaveReason<SomeReason>(expectedError);
+
+            action.Should().NotThrow();
+        }
+
+        [Fact]
+        public void A_result_without_expected_reason_of_type_throw_a_exception()
+        {
+            var successResult = Result.Fail<int>("Error 1");
+
+            Action action = () => successResult.Should().BeFailure().And.HaveReason<SomeReason>("Error 1");
+
+            action.Should()
+                .Throw<XunitException>()
+                .WithMessage("Expected result to contain reason of type \"SomeReason\" with message containing \"Error 1\", but found reasons '{Error with Message='Error 1'}'");
+        }
+
+        [Fact]
+        public void A_result_with_expected_reason_object_throw_no_exception()
+        {
+            var successResult = Result.Fail<int>("Error 1");
+
+            Action action = () => successResult.Should().BeFailure().And.HaveReason(new Error("Error 1"));
+
+            action.Should().NotThrow();
+        }
+
+        [Fact]
+        public void A_result_without_expected_reason_object_throw_a_exception()
+        {
+            var successResult = Result.Fail<int>("Error 1");
+
+            Action action = () => successResult.Should().BeFailure().And.HaveReason(new Error("Error 2"));
+
+            action.Should()
+                .Throw<XunitException>()
+                .WithMessage("Expected Subject.Reasons {Error with Message='Error 1'} to contain equivalent of Error with Message='Error 2'*");
+        }
+    }
+}

--- a/src/FluentResults.Extensions.FluentAssertions/ResultAssertions.cs
+++ b/src/FluentResults.Extensions.FluentAssertions/ResultAssertions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using FluentAssertions;
 using FluentAssertions.Execution;
 using FluentAssertions.Primitives;
@@ -38,6 +39,35 @@ namespace FluentResults.Extensions.FluentAssertions
                 .Given(() => Subject.IsSuccess)
                 .ForCondition(isSuccess => isSuccess)
                 .FailWith("Expected result be success, but is failed because of '{0}'", Subject.Errors);
+
+            return new AndWhichConstraint<ResultAssertions, Result>(this, Subject);
+        }
+
+        public AndWhichConstraint<ResultAssertions, Result> HaveReason(string message, string because = "", params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .Given(() => Subject.Reasons)
+                .ForCondition(reasons => reasons.Any(reason => reason.Message.Contains(message)))
+                .FailWith("Expected result to contain reason with message containing {0}, but found reasons '{1}'", message, Subject.Reasons);
+
+            return new AndWhichConstraint<ResultAssertions, Result>(this, Subject);
+        }
+
+        public AndWhichConstraint<ResultAssertions, Result> HaveReason<TReason>(string message, string because = "", params object[] becauseArgs) where TReason : IReason
+        {
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .Given(() => Subject.Reasons.OfType<TReason>())
+                .ForCondition(reasons => reasons.Any(reason => reason.Message.Contains(message)))
+                .FailWith("Expected result to contain reason of type {0} with message containing {1}, but found reasons '{2}'", typeof(TReason).Name, message, Subject.Reasons);
+
+            return new AndWhichConstraint<ResultAssertions, Result>(this, Subject);
+        }
+
+        public AndWhichConstraint<ResultAssertions, Result> HaveReason(IReason reason, string because = "", params object[] becauseArgs)
+        {
+            Subject.Reasons.Should().ContainEquivalentOf(reason, because, becauseArgs);
 
             return new AndWhichConstraint<ResultAssertions, Result>(this, Subject);
         }
@@ -82,6 +112,35 @@ namespace FluentResults.Extensions.FluentAssertions
                 .Given(() => Subject.IsSuccess)
                 .ForCondition(actualIsSuccess => actualIsSuccess)
                 .FailWith("Expected result be success, but is failed because of '{0}'", Subject.Errors);
+
+            return new AndWhichConstraint<ResultAssertions<T>, Result<T>>(this, Subject);
+        }
+
+        public AndWhichConstraint<ResultAssertions<T>, Result<T>> HaveReason(string message, string because = "", params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .Given(() => Subject.Reasons)
+                .ForCondition(reasons => reasons.Any(reason => reason.Message.Contains(message)))
+                .FailWith("Expected result to contain reason with message containing {0}, but found reasons '{1}'", message, Subject.Reasons);
+
+            return new AndWhichConstraint<ResultAssertions<T>, Result<T>>(this, Subject);
+        }
+
+        public AndWhichConstraint<ResultAssertions<T>, Result<T>> HaveReason<TReason>(string message, string because = "", params object[] becauseArgs) where TReason : IReason
+        {
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .Given(() => Subject.Reasons.OfType<TReason>())
+                .ForCondition(reasons => reasons.Any(reason => reason.Message.Contains(message)))
+                .FailWith("Expected result to contain reason of type {0} with message containing {1}, but found reasons '{2}'", typeof(TReason).Name, message, Subject.Reasons);
+
+            return new AndWhichConstraint<ResultAssertions<T>, Result<T>>(this, Subject);
+        }
+
+        public AndWhichConstraint<ResultAssertions<T>, Result<T>> HaveReason(IReason reason, string because = "", params object[] becauseArgs)
+        {
+            Subject.Reasons.Should().ContainEquivalentOf(reason, because, becauseArgs);
 
             return new AndWhichConstraint<ResultAssertions<T>, Result<T>>(this, Subject);
         }


### PR DESCRIPTION
Hi, it would be great to have some additional methods to make asserting reasons easier.

Here are some examples of their use that I run into often.
```cs
var result = Result.Fail<Foo>(new NotFoundError("Not Found"));
result.Should().BeFailure().And.HaveReason<NotFoundError>("Not Found");

var result = Result.Fail("Failed");
result.Should().BeFailure().And.HaveReason("Failed");
```