### PR TITLE
Added covariant interfaces for Result classes

### DIFF
--- a/src/FluentResults/Results/Result.cs
+++ b/src/FluentResults/Results/Result.cs
@@ -16,7 +16,20 @@ namespace FluentResults
         }
     }
 
-    public class Result<TValue> : ResultBase<Result<TValue>>
+    public interface IResult<out TValue> : IResultBase
+    {
+        /// <summary>
+        /// Get the Value. If result is failed then an Exception is thrown because a failed result has no value. Opposite see property ValueOrDefault.
+        /// </summary>
+        TValue Value { get; }
+
+        /// <summary>
+        /// Get the Value. If result is failed then a default value is returned. Opposite see property Value.
+        /// </summary>
+        TValue ValueOrDefault { get; }
+    }
+
+    public class Result<TValue> : ResultBase<Result<TValue>>, IResult<TValue>
     {
         public Result()
         { }
@@ -24,12 +37,12 @@ namespace FluentResults
         private TValue _value;
 
         /// <summary>
-        /// Get the Value. If result is failed then a default value is returned. Opposite see property Value.
+        /// <inheritdoc/>
         /// </summary>
         public TValue ValueOrDefault => _value;
 
         /// <summary>
-        /// Get the Value. If result is failed then an Exception is thrown because a failed result has no value. Opposite see property ValueOrDefault.
+        /// <inheritdoc/>
         /// </summary>
         public TValue Value
         {

--- a/src/FluentResults/Results/ResultBase.cs
+++ b/src/FluentResults/Results/ResultBase.cs
@@ -5,30 +5,58 @@ using System.Linq;
 // ReSharper disable once CheckNamespace
 namespace FluentResults
 {
-    public abstract class ResultBase
+    public interface IResultBase
     {
         /// <summary>
         /// Is true if Reasons contains at least one error
         /// </summary>
-        public bool IsFailed => Reasons.OfType<IError>().Any();
+        bool IsFailed { get; }
 
         /// <summary>
         /// Is true if Reasons contains no errors
         /// </summary>
-        public bool IsSuccess => !IsFailed;
+        bool IsSuccess { get; }
 
         /// <summary>
         /// Get all reasons (errors and successes)
         /// </summary>
-        public List<IReason> Reasons { get; }
+        List<IReason> Reasons { get; }
 
         /// <summary>
         /// Get all errors
         /// </summary>
-        public List<IError> Errors => Reasons.OfType<IError>().ToList();
+        List<IError> Errors { get; }
 
         /// <summary>
         /// Get all successes
+        /// </summary>
+        List<ISuccess> Successes { get; }
+    }
+
+    public abstract class ResultBase : IResultBase
+    {
+        /// <summary>
+        /// <inheritdoc/>
+        /// </summary>
+        public bool IsFailed => Reasons.OfType<IError>().Any();
+
+        /// <summary>
+        /// <inheritdoc/>
+        /// </summary>
+        public bool IsSuccess => !IsFailed;
+        
+        /// <summary>
+        /// <inheritdoc/>
+        /// </summary>
+        public List<IReason> Reasons { get; }
+
+        /// <summary>
+        /// <inheritdoc/>
+        /// </summary>
+        public List<IError> Errors => Reasons.OfType<IError>().ToList();
+
+        /// <summary>
+        /// <inheritdoc/>
         /// </summary>
         public List<ISuccess> Successes => Reasons.OfType<ISuccess>().ToList();
 
@@ -94,6 +122,7 @@ namespace FluentResults
 
     public abstract class ResultBase<TResult> : ResultBase
         where TResult : ResultBase<TResult>
+
     {
         /// <summary>
         /// Add a reason (success or error)


### PR DESCRIPTION
Hey there,

I've integrated your library into my project and figured out that `Result` classes don't support covariance and in some cases, it's at pains to use generics due to having a lot of explicit conversions. 

Here is a small example:
```csharp
interface IContract<T>
{
    Result<T> GetValueExplicitly();
    IResult<T> GetValueImplicitly();
}

abstract class BaseValue { } 

interface IContractExecutor : IContract<BaseValue> {}

class ContractExecutor<T> : IContractExecutor where T: BaseValue, new()
{
    public Result<BaseValue> GetValueExplicitly() 
    { 
        return Result.Ok((BaseValue) new T()); 
    }
    
    public IResult<BaseValue> GetValueImplicitly() 
    { 
        return Result.Ok(new T());
    }
}
```

Hope you find it useful and thanks for the cool Result implementation!