### PR TITLE
Conditional logging and additional log information

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,24 +362,24 @@ result.HasException<MyCustomException>(MyCustomException => MyCustomException.My
 
 ### Logging
 
-Sometimes it is necessary to log results. First create a logger. 
+Sometimes it is necessary to log results. First create a logger:
 
 ```csharp
 public class MyConsoleLogger : IResultLogger
 {
-    public void Log(string context, ResultBase result)
+    public void Log(string context, string content, ResultBase result)
     {
-        Console.WriteLine("{0}", result);
+        Console.WriteLine("Result: {0} {1} <{2}>", result.Reasons.Select(reason => reason.Message), content, context);
     }
 
-    public void Log<TContext>(ResultBase result)
+    public void Log<TContext>(string content, ResultBase result)
     {
-        Console.WriteLine("{0}", result);
+        Console.WriteLine("Result: {0} {1} <{2}>", result.Reasons.Select(reason => reason.Message), content, typeof(TContext).FullName);
     }
 }
 ```
 
-Then you have to register your logger. 
+Then you must register your logger in the Result settings:
 
 ```csharp
 var myLogger = new MyConsoleLogger();
@@ -388,22 +388,32 @@ Result.Setup(cfg => {
 });
 ```
 
-Finally the logger can be used. 
+Finally the logger can be used on any result:
 
 ```csharp
 var result = Result.Fail("Operation failed")
     .Log();
 ```
 
-Additionally, a context can be passed in form of a string or of a generic type parameter. 
+Additionally, a context can be passed in form of a string or of a generic type parameter. A custom message that provide more information can also be passed as content.
 
 ```csharp
 var result = Result.Fail("Operation failed")
-    .Log("logger context");
+    .Log("logger context", "More info about the result");
 
 var result2 = Result.Fail("Operation failed")
-    .Log<MyLoggerContext>();
+    .Log<MyLoggerContext>("More info about the result");
 ```
+
+You can also log results only on successes ou failures:
+
+```csharp
+Result<int> result = DoSomething();
+
+result.LogIfSuccess();
+result.LogIfFailed();
+```
+
 
 ### Asserting FluentResult objects
 

--- a/README.md
+++ b/README.md
@@ -405,7 +405,7 @@ var result2 = Result.Fail("Operation failed")
     .Log<MyLoggerContext>("More info about the result");
 ```
 
-You can also log results only on successes ou failures:
+You can also log results only on successes or failures:
 
 ```csharp
 Result<int> result = DoSomething();

--- a/src/FluentResults.Test/Mocks/LoggingMock.cs
+++ b/src/FluentResults.Test/Mocks/LoggingMock.cs
@@ -2,19 +2,22 @@
 {
     public class LoggingMock : IResultLogger
     {
-        public void Log(string context, ResultBase result)
+        public void Log(string context, string content, ResultBase result)
         {
             LoggedContext = context;
+            LoggedContent = content;
             LoggedResult = result;
         }
 
-        public void Log<TContext>(ResultBase result)
+        public void Log<TContext>(string content, ResultBase result)
         {
             LoggedContext = typeof(TContext).ToString();
+            LoggedContent = content;
             LoggedResult = result;
         }
 
         public string LoggedContext { get; private set; }
+        public string LoggedContent { get; private set; }
         public ResultBase LoggedResult { get; private set; }
     }
 }

--- a/src/FluentResults.Test/ResultLoggingTests.cs
+++ b/src/FluentResults.Test/ResultLoggingTests.cs
@@ -21,6 +21,7 @@ namespace FluentResults.Test
 
             // Assert
             logger.LoggedContext.Should().Be(string.Empty);
+            logger.LoggedContent.Should().BeNullOrEmpty();
             logger.LoggedResult.Should().NotBeNull();
         }
 
@@ -40,6 +41,7 @@ namespace FluentResults.Test
 
             // Assert
             logger.LoggedContext.Should().Be(context);
+            logger.LoggedContent.Should().BeNullOrEmpty();
             logger.LoggedResult.Should().NotBeNull();
         }
 
@@ -58,7 +60,125 @@ namespace FluentResults.Test
 
             // Assert
             logger.LoggedContext.Should().Be(typeof(Result).ToString());
+            logger.LoggedContent.Should().BeNullOrEmpty();
             logger.LoggedResult.Should().NotBeNull();
+        }
+
+        [Fact]
+        public void LogOkResultWithContent_EmptySuccess()
+        {
+            // Arrange
+            var context = "context";
+            var content = "content";
+            var logger = new LoggingMock();
+            Result.Setup(cfg => {
+                cfg.Logger = logger;
+            });
+
+            // Act
+            Result.Ok()
+                .Log(context, content);
+
+            // Assert
+            logger.LoggedContext.Should().Be(context);
+            logger.LoggedContent.Should().Be(content);
+            logger.LoggedResult.Should().NotBeNull();
+        }
+
+        [Fact]
+        public void LogOkResultWithContentAndTypedContext_EmptySuccess()
+        {
+            // Arrange
+            var content = "content";
+            var logger = new LoggingMock();
+            Result.Setup(cfg => {
+                cfg.Logger = logger;
+            });
+
+            // Act
+            Result.Ok()
+                .Log<Result>(content);
+
+            // Assert
+            logger.LoggedContext.Should().Be(typeof(Result).ToString());
+            logger.LoggedContent.Should().Be(content);
+            logger.LoggedResult.Should().NotBeNull();
+        }
+
+        [Fact]
+        public void OkResultLogWhenSuccess_EmptySuccess()
+        {
+            // Arrange
+            var logger = new LoggingMock();
+            Result.Setup(cfg => {
+                cfg.Logger = logger;
+            });
+
+            // Act
+            Result.Ok()
+                .LogIfSuccess();
+
+            // Assert
+            logger.LoggedContext.Should().BeNullOrEmpty();
+            logger.LoggedContent.Should().BeNull();
+            logger.LoggedResult.Should().NotBeNull();
+        }
+
+        [Fact]
+        public void FailedResultLogWhenFailed_Empty()
+        {
+            // Arrange
+            var logger = new LoggingMock();
+            Result.Setup(cfg => {
+                cfg.Logger = logger;
+            });
+
+            // Act
+            Result.Fail("")
+                .LogIfFailed();
+
+            // Assert
+            logger.LoggedContext.Should().BeNullOrEmpty();
+            logger.LoggedContent.Should().BeNull();
+            logger.LoggedResult.Should().NotBeNull();
+        }
+
+        [Fact]
+        public void FailedResultLogWhenSuccess_EmptySuccess()
+        {
+            // Arrange
+            var logger = new LoggingMock();
+            Result.Setup(cfg => {
+                cfg.Logger = logger;
+            });
+
+            // Act
+            Result.Fail("")
+                .LogIfSuccess();
+
+            // Assert
+            logger.LoggedContext.Should().BeNullOrEmpty();
+            logger.LoggedContent.Should().BeNull();
+            logger.LoggedResult.Should().BeNull();
+        }
+
+        [Fact]
+        public void OkResultLogWhenFailed_Empty()
+        {
+            // Arrange
+            var logger = new LoggingMock();
+            Result.Setup(cfg => {
+                cfg.Logger = logger;
+            });
+
+            // Act
+            Result.Ok()
+                .LogIfFailed();
+
+            // Assert
+            logger.LoggedContext.Should().BeNullOrEmpty();
+            logger.LoggedContent.Should().BeNull();
+            logger.LoggedResult.Should().BeNull();
         }
     }
 }

--- a/src/FluentResults/Logging/DefaultLogger.cs
+++ b/src/FluentResults/Logging/DefaultLogger.cs
@@ -3,12 +3,12 @@ namespace FluentResults
 {
     public class DefaultLogger : IResultLogger
     {
-        public void Log(string context, ResultBase result)
+        public void Log(string context, string content, ResultBase result)
         {
 
         }
 
-        public void Log<TContext>(ResultBase result)
+        public void Log<TContext>(string content, ResultBase result)
         {
 
         }

--- a/src/FluentResults/Logging/IResultLogger.cs
+++ b/src/FluentResults/Logging/IResultLogger.cs
@@ -3,7 +3,7 @@ namespace FluentResults
 {
     public interface IResultLogger
     {
-        void Log(string context, ResultBase result);
-        void Log<TContext>(ResultBase result);
+        void Log(string context, string content, ResultBase result);
+        void Log<TContext>(string content, ResultBase result);
     }
 }

--- a/src/FluentResults/Results/ResultBase.cs
+++ b/src/FluentResults/Results/ResultBase.cs
@@ -44,7 +44,7 @@ namespace FluentResults
         /// <inheritdoc/>
         /// </summary>
         public bool IsSuccess => !IsFailed;
-        
+
         /// <summary>
         /// <inheritdoc/>
         /// </summary>
@@ -94,7 +94,7 @@ namespace FluentResults
 
             return ResultHelper.HasError(Errors, predicate);
         }
-        
+
         /// <summary>
         /// Check if the result object contains an exception from a specific type
         /// </summary>
@@ -236,13 +236,13 @@ namespace FluentResults
         }
 
         /// <summary>
-        /// Log the result with a specific logger context
+        /// Log the result with a specific logger context. Configure the logger via Result.Setup(..)
         /// </summary>
-        public TResult Log(string context)
+        public TResult Log(string context, string content = null)
         {
             var logger = Result.Settings.Logger;
 
-            logger.Log(context, this);
+            logger.Log(context, content, this);
 
             return (TResult)this;
         }
@@ -250,15 +250,92 @@ namespace FluentResults
         /// <summary>
         /// Log the result with a typed context. Configure the logger via Result.Setup(..)
         /// </summary>
-        public TResult Log<TContext>()
+        public TResult Log<TContext>(string content = null)
         {
             var logger = Result.Settings.Logger;
 
-            logger.Log<TContext>(this);
+            logger.Log<TContext>(content, this);
 
             return (TResult)this;
         }
 
+        /// <summary>
+        /// Log the result only when it is successful. Configure the logger via Result.Setup(..)
+        /// </summary>
+        public TResult LogIfSuccess()
+        {
+            if (IsSuccess)
+            {
+                return Log();
+            }
+
+            return (TResult)this;
+        }
+
+        /// <summary>
+        /// Log the result with a specific logger context only when it is successful. Configure the logger via Result.Setup(..)
+        /// </summary>
+        public TResult LogIfSuccess(string context, string content = null)
+        {
+            if (IsSuccess)
+            {
+                return Log(context, content);
+            }
+
+            return (TResult)this;
+        }
+
+        /// <summary>
+        /// Log the result with a typed context only when it is successful. Configure the logger via Result.Setup(..)
+        /// </summary>
+        public TResult LogIfSuccess<TContext>(string content = null)
+        {
+            if (IsSuccess)
+            {
+                return Log<TContext>(content);
+            }
+
+            return (TResult)this;
+        }
+
+        /// <summary>
+        /// Log the result only when it is failed. Configure the logger via Result.Setup(..)
+        /// </summary>
+        public TResult LogIfFailed()
+        {
+            if (IsFailed)
+            {
+                return Log();
+            }
+
+            return (TResult)this;
+        }
+
+        /// <summary>
+        /// Log the result with a specific logger context only when it is failed. Configure the logger via Result.Setup(..)
+        /// </summary>
+        public TResult LogIfFailed(string context, string content = null)
+        {
+            if (IsFailed)
+            {
+                return Log(context, content);
+            }
+
+            return (TResult)this;
+        }
+
+        /// <summary>
+        /// Log the result with a typed context only when it is failed. Configure the logger via Result.Setup(..)
+        /// </summary>
+        public TResult LogIfFailed<TContext>(string content = null)
+        {
+            if (IsFailed)
+            {
+                return Log<TContext>(content);
+            }
+
+            return (TResult)this;
+        }
 
         public override string ToString()
         {


### PR DESCRIPTION
Hi,

This is something that I've been using for some time as extensions methods, thought would be nice to contribute it back.

This PR adds two new methods for logging:
```csharp
result.LogIfSuccess();
result.LogIfFailed();
```
I know we can achieve that directly in the `IResultLogger` implementation, but I thought will be nice to have some easier shortcuts.

And a new property for .Log() named `content`. This way we can pass additional information directly to the logging methods, without messing with metadatas.
```csharp
var result2 = Result.Fail("Operation failed")
    .Log<MyLoggerContext>("More info about the result");
```

Hope that would help someone, as it helped me!