### PR TITLE
CausedBy IError

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,7 +405,7 @@ var result2 = Result.Fail("Operation failed")
     .Log<MyLoggerContext>("More info about the result");
 ```
 
-You can also log results only on successes ou failures:
+You can also log results only on successes or failures:
 
 ```csharp
 Result<int> result = DoSomething();

--- a/src/FluentResults.Test/CheckReasonsTests.cs
+++ b/src/FluentResults.Test/CheckReasonsTests.cs
@@ -6,11 +6,12 @@ namespace FluentResults.Test
     public class CheckReasonsTests
     {
         class CustomException : System.Exception
-        {  
+        {
             public int Id { get; }
+
             public CustomException(int id) : base("Custom exception")
             {
-                     Id = id;
+                Id = id;
             }
         }
 
@@ -68,7 +69,7 @@ namespace FluentResults.Test
             result.HasException<CustomException>().Should().BeTrue();
         }
 
-       [Fact]
+        [Fact]
         public void HasExceptionInVeryDeepNestedError_WithoutSearchedError()
         {
             var result = Result.Ok()
@@ -83,7 +84,7 @@ namespace FluentResults.Test
             result.HasException<CustomException>().Should().BeTrue();
         }
 
-       [Fact]
+        [Fact]
         public void HasExceptionInVeryDeepNestedErrorWithPredicate_WithoutSearchedError()
         {
             var result = Result.Ok()
@@ -161,6 +162,17 @@ namespace FluentResults.Test
         }
 
         [Fact]
+        public void HasErrorInNestedErrorWithPredicate_WithoutSearchedError()
+        {
+            var originalResult = Result.Fail(new NotFoundError(1));
+            var result = Result.Fail(new NotFoundError(2)
+                    .CausedBy(originalResult.Errors));
+
+            result.HasError<NotFoundError>(e => e.Id == 1).Should().BeTrue();
+            result.HasError<NotFoundError>(e => e.Id == 2).Should().BeTrue();
+        }
+
+        [Fact]
         public void HasErrorWithMetadataKey_WithSearchedError()
         {
             var result = Result.Fail(new Error("").WithMetadata("MetadataKey1", "MetadataValue1"));
@@ -173,7 +185,7 @@ namespace FluentResults.Test
         {
             var result = Result.Fail(new Error("").WithMetadata("MetadataKey1", "MetadataValue1"));
 
-            result.HasError(e => e.HasMetadata("MetadataKey1", metadataValue => (string)metadataValue == "MetadataValue1")).Should().BeTrue();
+            result.HasError(e => e.HasMetadata("MetadataKey1", metadataValue => (string) metadataValue == "MetadataValue1")).Should().BeTrue();
         }
 
         [Fact]
@@ -181,7 +193,7 @@ namespace FluentResults.Test
         {
             var result = Result.Fail(new Error(""));
 
-            result.HasError(e => e.HasMetadata("MetadataKey1", metadataValue => (string)metadataValue == "MetadataValue1")).Should().BeFalse();
+            result.HasError(e => e.HasMetadata("MetadataKey1", metadataValue => (string) metadataValue == "MetadataValue1")).Should().BeFalse();
         }
 
         [Fact]

--- a/src/FluentResults/Reasons/Error.cs
+++ b/src/FluentResults/Reasons/Error.cs
@@ -46,25 +46,13 @@ namespace FluentResults
         /// </summary>
         /// <param name="message">Discription of the error</param>
         /// <param name="causedBy">The root cause of the <see cref="Error"/></param>
-        public Error(string message, Error causedBy)
+        public Error(string message, IError causedBy)
             : this(message)
         {
             if (causedBy == null)
                 throw new ArgumentNullException(nameof(causedBy));
 
             Reasons.Add(causedBy);
-        }
-
-        /// <summary>
-        /// Set the root cause of the error
-        /// </summary>
-        public Error CausedBy(Error error)
-        {
-            if (error == null)
-                throw new ArgumentNullException(nameof(error));
-
-            Reasons.Add(error);
-            return this;
         }
 
         /// <summary>
@@ -109,18 +97,6 @@ namespace FluentResults
         public Error CausedBy(string message)
         {
             Reasons.Add(Result.Settings.ErrorFactory(message));
-            return this;
-        }
-
-        /// <summary>
-        /// Set the root cause of the error
-        /// </summary>
-        public Error CausedBy(IEnumerable<Error> errors)
-        {
-            if (errors == null)
-                throw new ArgumentNullException(nameof(errors));
-
-            Reasons.AddRange(errors);
             return this;
         }
 

--- a/src/FluentResults/Reasons/Error.cs
+++ b/src/FluentResults/Reasons/Error.cs
@@ -24,7 +24,7 @@ namespace FluentResults
         /// Get the reasons of an error
         /// </summary>
         public List<IError> Reasons { get; }
-        
+
         protected Error()
         {
             Metadata = new Dictionary<string, object>();
@@ -70,6 +70,18 @@ namespace FluentResults
         /// <summary>
         /// Set the root cause of the error
         /// </summary>
+        public Error CausedBy(IError error)
+        {
+            if (error == null)
+                throw new ArgumentNullException(nameof(error));
+
+            Reasons.Add(error);
+            return this;
+        }
+
+        /// <summary>
+        /// Set the root cause of the error
+        /// </summary>
         public Error CausedBy(Exception exception)
         {
             if (exception == null)
@@ -104,6 +116,18 @@ namespace FluentResults
         /// Set the root cause of the error
         /// </summary>
         public Error CausedBy(IEnumerable<Error> errors)
+        {
+            if (errors == null)
+                throw new ArgumentNullException(nameof(errors));
+
+            Reasons.AddRange(errors);
+            return this;
+        }
+
+        /// <summary>
+        /// Set the root cause of the error
+        /// </summary>
+        public Error CausedBy(IEnumerable<IError> errors)
         {
             if (errors == null)
                 throw new ArgumentNullException(nameof(errors));


### PR DESCRIPTION
Hi,

Is there a reason why `CausedBy` only allows passing `Error` and not `IError`?

```csharp
var result1 = Result.Fail("Some error");
var result2 = Result.Fail(new Error("Another error").CausedBy(result1.Errors));
```