### PR TITLE
Result logging with LogLevel

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,12 @@ var result2 = Result.Fail("Operation failed")
     .Log<MyLoggerContext>("More info about the result");
 ```
 
+It's also possible to specify the desired log level:
+```csharp
+var result = Result.Ok().Log(LogLevel.Debug);
+var result = Result.Fail().Log<MyContext>("Additional context", LogLevel.Error);
+```
+
 You can also log results only on successes or failures:
 
 ```csharp

--- a/src/FluentResults.Test/Mocks/LoggingMock.cs
+++ b/src/FluentResults.Test/Mocks/LoggingMock.cs
@@ -1,23 +1,28 @@
-﻿namespace FluentResults.Test.Mocks
+﻿using Microsoft.Extensions.Logging;
+
+namespace FluentResults.Test.Mocks
 {
     public class LoggingMock : IResultLogger
     {
-        public void Log(string context, string content, ResultBase result)
+        public void Log(string context, string content, ResultBase result, LogLevel logLevel = LogLevel.Information)
         {
             LoggedContext = context;
             LoggedContent = content;
             LoggedResult = result;
+            LoggedLevel = logLevel;
         }
 
-        public void Log<TContext>(string content, ResultBase result)
+        public void Log<TContext>(string content, ResultBase result, LogLevel logLevel = LogLevel.Information)
         {
             LoggedContext = typeof(TContext).ToString();
             LoggedContent = content;
             LoggedResult = result;
+            LoggedLevel = logLevel;
         }
 
         public string LoggedContext { get; private set; }
         public string LoggedContent { get; private set; }
         public ResultBase LoggedResult { get; private set; }
+        public LogLevel LoggedLevel { get; private set; }
     }
 }

--- a/src/FluentResults.Test/ResultLoggingTests.cs
+++ b/src/FluentResults.Test/ResultLoggingTests.cs
@@ -1,5 +1,6 @@
 ﻿using FluentAssertions;
 using FluentResults.Test.Mocks;
+using Microsoft.Extensions.Logging;
 using Xunit;
 
 namespace FluentResults.Test
@@ -23,6 +24,7 @@ namespace FluentResults.Test
             logger.LoggedContext.Should().Be(string.Empty);
             logger.LoggedContent.Should().BeNullOrEmpty();
             logger.LoggedResult.Should().NotBeNull();
+            logger.LoggedLevel.Should().Be(LogLevel.Information);
         }
 
         [Fact]
@@ -43,6 +45,7 @@ namespace FluentResults.Test
             logger.LoggedContext.Should().Be(context);
             logger.LoggedContent.Should().BeNullOrEmpty();
             logger.LoggedResult.Should().NotBeNull();
+            logger.LoggedLevel.Should().Be(LogLevel.Information);
         }
 
         [Fact]
@@ -62,6 +65,7 @@ namespace FluentResults.Test
             logger.LoggedContext.Should().Be(typeof(Result).ToString());
             logger.LoggedContent.Should().BeNullOrEmpty();
             logger.LoggedResult.Should().NotBeNull();
+            logger.LoggedLevel.Should().Be(LogLevel.Information);
         }
 
         [Fact]
@@ -83,6 +87,7 @@ namespace FluentResults.Test
             logger.LoggedContext.Should().Be(context);
             logger.LoggedContent.Should().Be(content);
             logger.LoggedResult.Should().NotBeNull();
+            logger.LoggedLevel.Should().Be(LogLevel.Information);
         }
 
         [Fact]
@@ -103,6 +108,111 @@ namespace FluentResults.Test
             logger.LoggedContext.Should().Be(typeof(Result).ToString());
             logger.LoggedContent.Should().Be(content);
             logger.LoggedResult.Should().NotBeNull();
+            logger.LoggedLevel.Should().Be(LogLevel.Information);
+        }
+
+        [Fact]
+        public void LogOkResultLevel_EmptySuccess()
+        {
+            // Arrange
+            var logger = new LoggingMock();
+            Result.Setup(cfg => {
+                cfg.Logger = logger;
+            });
+
+            // Act
+            Result.Ok()
+                .Log(LogLevel.Critical);
+
+            // Assert
+            logger.LoggedContext.Should().BeNullOrEmpty();
+            logger.LoggedContent.Should().BeNullOrEmpty();
+            logger.LoggedResult.Should().NotBeNull();
+            logger.LoggedLevel.Should().Be(LogLevel.Critical);
+        }
+
+        [Fact]
+        public void LogOkResultWithContextAndLevel_EmptySuccess()
+        {
+            // Arrange
+            var context = "context";
+            var logger = new LoggingMock();
+            Result.Setup(cfg => {
+                cfg.Logger = logger;
+            });
+
+            // Act
+            Result.Ok()
+                .Log(context, LogLevel.Critical);
+
+            // Assert
+            logger.LoggedContext.Should().Be(context);
+            logger.LoggedContent.Should().BeNullOrEmpty();
+            logger.LoggedResult.Should().NotBeNull();
+            logger.LoggedLevel.Should().Be(LogLevel.Critical);
+        }
+
+        [Fact]
+        public void LogOkResultWithTypedContextAndLevel_EmptySuccess()
+        {
+            // Arrange
+            var logger = new LoggingMock();
+            Result.Setup(cfg => {
+                cfg.Logger = logger;
+            });
+
+            // Act
+            Result.Ok()
+                .Log<Result>(LogLevel.Critical);
+
+            // Assert
+            logger.LoggedContext.Should().Be(typeof(Result).ToString());
+            logger.LoggedContent.Should().BeNullOrEmpty();
+            logger.LoggedResult.Should().NotBeNull();
+            logger.LoggedLevel.Should().Be(LogLevel.Critical);
+        }
+
+        [Fact]
+        public void LogOkResultWithContentAndLevel_EmptySuccess()
+        {
+            // Arrange
+            var context = "context";
+            var content = "content";
+            var logger = new LoggingMock();
+            Result.Setup(cfg => {
+                cfg.Logger = logger;
+            });
+
+            // Act
+            Result.Ok()
+                .Log(context, content, LogLevel.Critical);
+
+            // Assert
+            logger.LoggedContext.Should().Be(context);
+            logger.LoggedContent.Should().Be(content);
+            logger.LoggedResult.Should().NotBeNull();
+            logger.LoggedLevel.Should().Be(LogLevel.Critical);
+        }
+
+        [Fact]
+        public void LogOkResultWithContentAndTypedContextAndLevel_EmptySuccess()
+        {
+            // Arrange
+            var content = "content";
+            var logger = new LoggingMock();
+            Result.Setup(cfg => {
+                cfg.Logger = logger;
+            });
+
+            // Act
+            Result.Ok()
+                .Log<Result>(content, LogLevel.Critical);
+
+            // Assert
+            logger.LoggedContext.Should().Be(typeof(Result).ToString());
+            logger.LoggedContent.Should().Be(content);
+            logger.LoggedResult.Should().NotBeNull();
+            logger.LoggedLevel.Should().Be(LogLevel.Critical);
         }
 
         [Fact]

--- a/src/FluentResults/FluentResults.csproj
+++ b/src/FluentResults/FluentResults.csproj
@@ -30,6 +30,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/src/FluentResults/Logging/DefaultLogger.cs
+++ b/src/FluentResults/Logging/DefaultLogger.cs
@@ -1,14 +1,17 @@
 ﻿// ReSharper disable once CheckNamespace
+
+using Microsoft.Extensions.Logging;
+
 namespace FluentResults
 {
     public class DefaultLogger : IResultLogger
     {
-        public void Log(string context, string content, ResultBase result)
+        public void Log(string context, string content, ResultBase result, LogLevel logLevel)
         {
 
         }
 
-        public void Log<TContext>(string content, ResultBase result)
+        public void Log<TContext>(string content, ResultBase result, LogLevel logLevel)
         {
 
         }

--- a/src/FluentResults/Logging/IResultLogger.cs
+++ b/src/FluentResults/Logging/IResultLogger.cs
@@ -1,9 +1,12 @@
 ﻿// ReSharper disable once CheckNamespace
+
+using Microsoft.Extensions.Logging;
+
 namespace FluentResults
 {
     public interface IResultLogger
     {
-        void Log(string context, string content, ResultBase result);
-        void Log<TContext>(string content, ResultBase result);
+        void Log(string context, string content, ResultBase result, LogLevel logLevel);
+        void Log<TContext>(string content, ResultBase result, LogLevel logLevel);
     }
 }

--- a/src/FluentResults/Results/ResultBase.cs
+++ b/src/FluentResults/Results/ResultBase.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Extensions.Logging;
 
 // ReSharper disable once CheckNamespace
 namespace FluentResults
@@ -230,19 +231,27 @@ namespace FluentResults
         /// <summary>
         /// Log the result. Configure the logger via Result.Setup(..)
         /// </summary>
-        public TResult Log()
+        public TResult Log(LogLevel logLevel = LogLevel.Information)
         {
-            return Log(string.Empty);
+            return Log(string.Empty, null, logLevel);
+        }
+
+        /// <summary>
+        /// Log the result. Configure the logger via Result.Setup(..)
+        /// </summary>
+        public TResult Log(string context, LogLevel logLevel = LogLevel.Information)
+        {
+            return Log(context, null, logLevel);
         }
 
         /// <summary>
         /// Log the result with a specific logger context. Configure the logger via Result.Setup(..)
         /// </summary>
-        public TResult Log(string context, string content = null)
+        public TResult Log(string context, string content, LogLevel logLevel = LogLevel.Information)
         {
             var logger = Result.Settings.Logger;
 
-            logger.Log(context, content, this);
+            logger.Log(context, content, this, logLevel);
 
             return (TResult)this;
         }
@@ -250,11 +259,19 @@ namespace FluentResults
         /// <summary>
         /// Log the result with a typed context. Configure the logger via Result.Setup(..)
         /// </summary>
-        public TResult Log<TContext>(string content = null)
+        public TResult Log<TContext>(LogLevel logLevel = LogLevel.Information)
+        {
+            return Log<TContext>(null, logLevel);
+        }
+
+        /// <summary>
+        /// Log the result with a typed context. Configure the logger via Result.Setup(..)
+        /// </summary>
+        public TResult Log<TContext>(string content, LogLevel logLevel = LogLevel.Information)
         {
             var logger = Result.Settings.Logger;
 
-            logger.Log<TContext>(content, this);
+            logger.Log<TContext>(content, this, logLevel);
 
             return (TResult)this;
         }
@@ -262,10 +279,10 @@ namespace FluentResults
         /// <summary>
         /// Log the result only when it is successful. Configure the logger via Result.Setup(..)
         /// </summary>
-        public TResult LogIfSuccess()
+        public TResult LogIfSuccess(LogLevel logLevel = LogLevel.Information)
         {
             if (IsSuccess)
-                return Log();
+                return Log(logLevel);
 
             return (TResult)this;
         }
@@ -273,10 +290,10 @@ namespace FluentResults
         /// <summary>
         /// Log the result with a specific logger context only when it is successful. Configure the logger via Result.Setup(..)
         /// </summary>
-        public TResult LogIfSuccess(string context, string content = null)
+        public TResult LogIfSuccess(string context, string content = null, LogLevel logLevel = LogLevel.Information)
         {
             if (IsSuccess)
-                return Log(context, content);
+                return Log(context, content, logLevel);
 
             return (TResult)this;
         }
@@ -284,10 +301,10 @@ namespace FluentResults
         /// <summary>
         /// Log the result with a typed context only when it is successful. Configure the logger via Result.Setup(..)
         /// </summary>
-        public TResult LogIfSuccess<TContext>(string content = null)
+        public TResult LogIfSuccess<TContext>(string content = null, LogLevel logLevel = LogLevel.Information)
         {
             if (IsSuccess)
-                return Log<TContext>(content);
+                return Log<TContext>(content, logLevel);
 
             return (TResult)this;
         }
@@ -295,10 +312,10 @@ namespace FluentResults
         /// <summary>
         /// Log the result only when it is failed. Configure the logger via Result.Setup(..)
         /// </summary>
-        public TResult LogIfFailed()
+        public TResult LogIfFailed(LogLevel logLevel = LogLevel.Information)
         {
             if (IsFailed)
-                return Log();
+                return Log(logLevel);
 
             return (TResult)this;
         }
@@ -306,10 +323,10 @@ namespace FluentResults
         /// <summary>
         /// Log the result with a specific logger context only when it is failed. Configure the logger via Result.Setup(..)
         /// </summary>
-        public TResult LogIfFailed(string context, string content = null)
+        public TResult LogIfFailed(string context, string content = null, LogLevel logLevel = LogLevel.Information)
         {
             if (IsFailed)
-                return Log(context, content);
+                return Log(context, content, logLevel);
 
             return (TResult)this;
         }
@@ -317,10 +334,10 @@ namespace FluentResults
         /// <summary>
         /// Log the result with a typed context only when it is failed. Configure the logger via Result.Setup(..)
         /// </summary>
-        public TResult LogIfFailed<TContext>(string content = null)
+        public TResult LogIfFailed<TContext>(string content = null, LogLevel logLevel = LogLevel.Information)
         {
             if (IsFailed)
-                return Log<TContext>(content);
+                return Log<TContext>(content, logLevel);
 
             return (TResult)this;
         }


### PR DESCRIPTION
Hi!

I thought would be nice if one could specify the desired logging level in the `.Log()` call.

Like so:
```csharp
var result = Result.Ok().Log(LogLevel.Debug);
var result = Result.Fail().Log<MyContext>("Additional context", LogLevel.Error);
```