### PR TITLE
Added support for creating a failed result with multiple errors

### DIFF
--- a/src/FluentResults.Test/ResultWithValueTests.cs
+++ b/src/FluentResults.Test/ResultWithValueTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
@@ -60,7 +61,34 @@ namespace FluentResults.Test
             result.IsFailed.Should().BeTrue();
             result.ValueOrDefault.Should().Be(0);
         }
+        
+        [Fact]
+        public void Fail_WithValidErrorMessages_ShouldReturnFailedResult()
+        {
+            // Act
+            var errors = new List<string> {"First error message", "Second error message"};
+            var result = Result.Fail<int>(errors);
 
+            // Assert
+            result.IsFailed.Should().BeTrue();
+            result.Reasons.Should().HaveCount(2);
+            result.Reasons[0].Should().BeOfType<Error>();
+            result.Reasons[1].Should().BeOfType<Error>();
+            result.Reasons[0].Message.Should().Be("First error message");
+            result.Reasons[1].Message.Should().Be("Second error message");
+            result.ValueOrDefault.Should().Be(0);
+        }
+        
+        [Fact]
+        public void Fail_WithNullEnumerableOfErrorMessages_ShouldThrow()
+        {
+            // Act
+            Action act = () => Result.Fail<int>((IEnumerable<string>)null);
+
+            // Assert
+            act.Should().Throw<ArgumentNullException>();
+        }
+        
         [Fact]
         public void ValueOrDefault_WithDateTime_ShouldReturnFailedResult()
         {
@@ -99,7 +127,7 @@ namespace FluentResults.Test
 
             // Assert
 
-            Action action = () => { var v = result.Value; };
+            Action action = () => { var _ = result.Value; };
 
             action.Should()
                 .Throw<InvalidOperationException>()
@@ -115,7 +143,7 @@ namespace FluentResults.Test
 
             // Assert
 
-            Action action = () => { var v = result.Value; };
+            Action action = () => { var _ = result.Value; };
 
             action.Should()
                 .Throw<InvalidOperationException>()
@@ -149,7 +177,7 @@ namespace FluentResults.Test
         }
 
         [Fact]
-        public void ToResult_ToAntotherValueType_ReturnFailedResult()
+        public void ToResult_ToAnotherValueType_ReturnFailedResult()
         {
             var valueResult = Result.Fail<int>("First error message");
 
@@ -161,7 +189,7 @@ namespace FluentResults.Test
         }
 
         [Fact]
-        public void ToResult_ToAntotherValueTypeWithOkResultAndNoConverter_ReturnFailedResult()
+        public void ToResult_ToAnotherValueTypeWithOkResultAndNoConverter_ReturnFailedResult()
         {
             var valueResult = Result.Fail<int>("Failed");
 
@@ -173,7 +201,7 @@ namespace FluentResults.Test
         }
 
         [Fact]
-        public void ToResult_ToAntotherValueTypeWithOkResultAndConverter_ReturnSuccessResult()
+        public void ToResult_ToAnotherValueTypeWithOkResultAndConverter_ReturnSuccessResult()
         {
             var valueResult = Result.Ok(4);
 
@@ -229,7 +257,7 @@ namespace FluentResults.Test
             var exception = new Exception("ex message");
             int Action() => throw exception;
 
-            var result = Result.Try(Action, e => new Error("xy"));
+            var result = Result.Try(Action, _ => new Error("xy"));
 
             result.IsSuccess.Should().BeFalse();
             result.Errors.Should().HaveCount(1);
@@ -271,7 +299,7 @@ namespace FluentResults.Test
             var exception = new Exception("ex message");
             Task<int> Action() => throw exception;
 
-            var result = await Result.Try(Action, e => new Error("xy"));
+            var result = await Result.Try(Action, _ => new Error("xy"));
 
             result.IsSuccess.Should().BeFalse();
             result.Errors.Should().HaveCount(1);

--- a/src/FluentResults.Test/ResultWithoutValueTests.cs
+++ b/src/FluentResults.Test/ResultWithoutValueTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Data.SqlTypes;
 using FluentAssertions;
 using System.Linq;
@@ -90,6 +91,31 @@ namespace FluentResults.Test
 
             // Assert
             valueResult.IsFailed.Should().BeTrue();
+        }
+        
+        [Fact]
+        public void CreateFailedResultWithListOfErrors_FailedResultWithErrors()
+        {
+            // Act
+            var errors = new List<string> {"First error message", "Second error message"};
+            var result = Result.Fail(errors);
+
+            // Assert
+            result.Reasons.Should().HaveCount(2);
+            result.Reasons[0].Should().BeOfType<Error>();
+            result.Reasons[1].Should().BeOfType<Error>();
+            result.Reasons[0].Message.Should().Be("First error message");
+            result.Reasons[1].Message.Should().Be("Second error message");
+        }
+        
+        [Fact]
+        public void Fail_WithNullEnumerableOfErrorMessages_ShouldThrow()
+        {
+            // Act
+            Action act = () => Result.Fail((IEnumerable<string>)null);
+
+            // Assert
+            act.Should().Throw<ArgumentNullException>();
         }
 
         [Fact]

--- a/src/FluentResults/Factories/Results.cs
+++ b/src/FluentResults/Factories/Results.cs
@@ -44,12 +44,25 @@ namespace FluentResults
         }
 
         /// <summary>
-        /// Creates a failed result with the given error message. Internally an error object from type `Error` is created. 
+        /// Creates a failed result with the given error message. Internally an error object from type <see cref="Error"/> is created. 
         /// </summary>
         public static Result Fail(string errorMessage)
         {
             var result = new Result();
             result.WithError(Settings.ErrorFactory(errorMessage));
+            return result;
+        }
+        
+        /// <summary>
+        /// Creates a failed result with the given error messages. Internally a list of error objects from type <see cref="Error"/> is created
+        /// </summary>
+        public static Result Fail(IEnumerable<string> errorMessages)
+        {
+            if (errorMessages == null)
+                throw new ArgumentNullException(nameof(errorMessages), "The list of error messages cannot be null");
+            
+            var result = new Result();
+            result.WithErrors(Settings.MultipleErrorFactory(errorMessages));
             return result;
         }
         
@@ -74,12 +87,25 @@ namespace FluentResults
         }
 
         /// <summary>
-        /// Creates a failed result with the given error message. Internally an error object from type Error is created. 
+        /// Creates a failed result with the given error message. Internally an error object from type <see cref="Error"/> is created. 
         /// </summary>
         public static Result<TValue> Fail<TValue>(string errorMessage)
         {
             var result = new Result<TValue>();
             result.WithError(Settings.ErrorFactory(errorMessage));
+            return result;
+        }
+        
+        /// <summary>
+        /// Creates a failed result with the given error messages. Internally a list of error objects from type <see cref="Error"/> is created. 
+        /// </summary>
+        public static Result<TValue> Fail<TValue>(IEnumerable<string> errorMessages)
+        {
+            if (errorMessages == null)
+                throw new ArgumentNullException(nameof(errorMessages), "The list of error messages cannot be null");
+            
+            var result = new Result<TValue>();
+            result.WithErrors(Settings.MultipleErrorFactory(errorMessages));
             return result;
         }
 

--- a/src/FluentResults/Settings/ResultSettings.cs
+++ b/src/FluentResults/Settings/ResultSettings.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 // ReSharper disable once CheckNamespace
 namespace FluentResults
@@ -12,6 +13,8 @@ namespace FluentResults
         public Func<string, ISuccess> SuccessFactory { get; set; }
 
         public Func<string, IError> ErrorFactory { get; set; }
+        
+        public Func<IEnumerable<string>, IEnumerable<IError>> MultipleErrorFactory { get; set; }
 
         public Func<string, Exception, IExceptionalError> ExceptionalErrorFactory { get; set; }
     }

--- a/src/FluentResults/Settings/ResultSettingsBuilder.cs
+++ b/src/FluentResults/Settings/ResultSettingsBuilder.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 
 // ReSharper disable once CheckNamespace
 namespace FluentResults
@@ -21,6 +23,11 @@ namespace FluentResults
         /// Factory to create an IError object. Used in all scenarios where an error is created within FluentResults. 
         /// </summary>
         public Func<string, IError> ErrorFactory { get; set; }
+        
+        /// <summary>
+        /// Factory to create multiple IError objects. Used in all scenarios where multiple errors are created at once within FluentResults. 
+        /// </summary>
+        public Func<IEnumerable<string>, IEnumerable<IError>> MultipleErrorFactory { get; set; }
 
         /// <summary>
         /// Factory to create an IExceptionalError object. Used in all scenarios where an exceptional error is created within FluentResults. 
@@ -35,6 +42,7 @@ namespace FluentResults
             DefaultTryCatchHandler = ex => Result.Settings.ExceptionalErrorFactory(ex.Message, ex);
             SuccessFactory = successMessage => new Success(successMessage);
             ErrorFactory = errorMessage => new Error(errorMessage);
+            MultipleErrorFactory = errors => errors.Select(e => new Error(e)); 
             ExceptionalErrorFactory = (errorMessage, exception) => new ExceptionalError(errorMessage ?? exception.Message, exception);
         }
 
@@ -46,6 +54,7 @@ namespace FluentResults
                 DefaultTryCatchHandler = DefaultTryCatchHandler,
                 SuccessFactory = SuccessFactory,
                 ErrorFactory = ErrorFactory,
+                MultipleErrorFactory = MultipleErrorFactory,
                 ExceptionalErrorFactory = ExceptionalErrorFactory
             };
         }


### PR DESCRIPTION
Extended Result classes to allow passing IEnumerable<string> representing the errors to be created.
The IEnumerable cannot be empty or it will throw an argument null exception.