### PR TITLE
add Deconstruct Operators to Result and ResultBase

### DIFF
--- a/src/FluentResults.Test/Playground.cs
+++ b/src/FluentResults.Test/Playground.cs
@@ -15,7 +15,7 @@ namespace FluentResults.Test
         public void Simple()
         {
             var voidResult = Result.Ok();
-            
+
             voidResult = Result.Ok()
                 .WithSuccess("This is a success")
                 .WithSuccess("This is a second success");
@@ -48,6 +48,13 @@ namespace FluentResults.Test
 
             IEnumerable<Result<int>> results2 = new List<Result<int>>();
             Result<IEnumerable<int>> mergedResult2 = results.Merge();
+
+            var (isSuccess, isFailed) = Result.Ok();
+            var (isSuccess0, isFailed0, errors0) = Result.Ok();
+            var (isSuccess1, isFailed1, value1) = Result.Ok(500);
+            var (isSuccess2, _, value2) = Result.Ok(500);
+            var (isSuccess3, _, errors3) = Result.Fail("First error");
+            var (isSuccess4, _, value4, errors4) = Result.Fail<int>("First error");
         }
 
         public void TestExtensions()

--- a/src/FluentResults.Test/ResultWithValueTests.cs
+++ b/src/FluentResults.Test/ResultWithValueTests.cs
@@ -405,5 +405,69 @@ namespace FluentResults.Test
             result.Value.Should().BeNull();
             result.ValueOrDefault.Should().BeNull();
         }
+        
+         [Fact]
+        public void Can_deconstruct_generic_Ok_to_isSuccess_and_isFailed()
+        {
+            var (isSuccess, isFailed) = Result.Ok(true);
+
+            isSuccess.Should().Be(true);
+            isFailed.Should().Be(false);
+        }
+
+        [Fact]
+        public void Can_deconstruct_generic_Fail_to_isSuccess_and_isFailed()
+        {
+            var (isSuccess, isFailed) = Result.Fail<bool>("fail");
+
+            isSuccess.Should().Be(false);
+            isFailed.Should().Be(true);
+        }
+
+        [Fact]
+        public void Can_deconstruct_generic_Ok_to_isSuccess_and_isFailed_and_value()
+        {
+            var (isSuccess, isFailed, value) = Result.Ok(100);
+
+            isSuccess.Should().Be(true);
+            isFailed.Should().Be(false);
+            value.Should().Be(100);
+        }
+        
+        [Fact]
+        public void Can_deconstruct_generic_Fail_to_isSuccess_and_isFailed_and_value()
+        {
+            var (isSuccess, isFailed, value) = Result.Fail<int>("fail");
+
+            isSuccess.Should().Be(false);
+            isFailed.Should().Be(true);
+            value.Should().Be(default);
+        }
+
+        [Fact]
+        public void Can_deconstruct_generic_Ok_to_isSuccess_and_isFailed_and_value_with_errors()
+        {
+            var (isSuccess, isFailed, value, errors) = Result.Ok(100);
+
+            isSuccess.Should().Be(true);
+            isFailed.Should().Be(false);
+            value.Should().Be(100);
+            errors.Should().BeNull();
+        }
+
+        [Fact]
+        public void Can_deconstruct_generic_Fail_to_isSuccess_and_isFailed_and_errors_with_value()
+        {
+            var error = new Error("fail");
+
+            var (isSuccess, isFailed, value, errors) = Result.Fail<bool>(error);
+
+            isSuccess.Should().Be(false);
+            isFailed.Should().Be(true);
+            value.Should().Be(default);
+
+            errors.Count.Should().Be(1);
+            errors.FirstOrDefault().Should().Be(error);
+        }
     }
 }

--- a/src/FluentResults.Test/ResultWithoutValueTests.cs
+++ b/src/FluentResults.Test/ResultWithoutValueTests.cs
@@ -353,5 +353,46 @@ namespace FluentResults.Test
             var error = result.Errors.First();
             error.Message.Should().Be("xy");
         }
+        
+        [Fact]
+        public void Can_deconstruct_non_generic_Ok_to_isSuccess_and_isFailed()
+        {
+            var (isSuccess, isFailed) = Result.Ok();
+
+            isSuccess.Should().Be(true);
+            isFailed.Should().Be(false);
+        }
+
+        [Fact]
+        public void Can_deconstruct_non_generic_Fail_to_isSuccess_and_isFailed()
+        {
+            var (isSuccess, isFailed) = Result.Fail("fail");
+
+            isSuccess.Should().Be(false);
+            isFailed.Should().Be(true);
+        }
+
+        [Fact]
+        public void Can_deconstruct_non_generic_Ok_to_isSuccess_and_isFailed_and_errors()
+        {
+            var (isSuccess, isFailed, errors) = Result.Ok();
+
+            isSuccess.Should().Be(true);
+            isFailed.Should().Be(false);
+            errors.Should().BeNull();
+        }
+
+        [Fact]
+        public void Can_deconstruct_non_generic_Fail_to_isSuccess_and_isFailed_and_errors()
+        {
+            var error = new Error("fail");
+            var (isSuccess, isFailed, errors) = Result.Fail(error);
+
+            isSuccess.Should().Be(false);
+            isFailed.Should().Be(true);
+            
+            errors.Count.Should().Be(1);
+            errors.FirstOrDefault().Should().Be(error);
+        }
     }
 }

--- a/src/FluentResults/Results/Result.cs
+++ b/src/FluentResults/Results/Result.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 // ReSharper disable once CheckNamespace
 namespace FluentResults
@@ -107,7 +108,34 @@ namespace FluentResults
         {
             return Result.Ok(value);
         }
-
+        
+        /// <summary>
+        /// Deconstruct Result
+        /// </summary>
+        /// <param name="isSuccess"></param>
+        /// <param name="isFailed"></param>
+        /// <param name="value"></param>
+        public void Deconstruct(out bool isSuccess, out bool isFailed, out TValue value)
+        {
+            isSuccess = IsSuccess;
+            isFailed = IsFailed;
+            value = IsSuccess ? Value : default;
+        }
+        /// <summary>
+        /// Deconstruct Result
+        /// </summary>
+        /// <param name="isSuccess"></param>
+        /// <param name="isFailed"></param>
+        /// <param name="value"></param>
+        /// <param name="errors"></param>
+        public void Deconstruct(out bool isSuccess, out bool isFailed, out TValue value, out List<IError> errors)
+        {
+            isSuccess = IsSuccess;
+            isFailed = IsFailed;
+            value = IsSuccess ? Value : default;
+            errors = IsFailed ? Errors : default;
+        }
+        
         private void ThrowIfFailed()
         {
             if (IsFailed)

--- a/src/FluentResults/Results/ResultBase.cs
+++ b/src/FluentResults/Results/ResultBase.cs
@@ -138,6 +138,31 @@ namespace FluentResults
         {
             return ResultHelper.HasSuccess(Successes, predicate);
         }
+
+        /// <summary>
+        /// Deconstruct Result 
+        /// </summary>
+        /// <param name="isSuccess"></param>
+        /// <param name="isFailed"></param>
+        public void Deconstruct(out bool isSuccess, out bool isFailed)
+        {
+            isSuccess = IsSuccess;
+            isFailed = IsFailed;
+        }
+        
+        /// <summary>
+        /// Deconstruct Result
+        /// </summary>
+        /// <param name="isSuccess"></param>
+        /// <param name="isFailed"></param>
+        /// <param name="errors"></param>
+        public void Deconstruct(out bool isSuccess, out bool isFailed, out List<IError> errors)
+        {
+            isSuccess = IsSuccess;
+            isFailed = IsFailed;
+            errors = IsFailed ? Errors : default;
+        }
+
     }
 
     public abstract class ResultBase<TResult> : ResultBase


### PR DESCRIPTION
Hello,

Currently, when you have a method that returns Result<TValue> you always need to check isSuccess with `result.IsSuccess` its all ok although
add some Deconstruction method can make it more simple 

 var (isSuccess, isFailure, value) = Result.Ok(100);
 var (isSuccess, value) = Result.Ok(100);
 var (isSuccess, value, errors) = Result.Success(100);
