### PR TITLE
Lazy error evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,20 @@ With the methods ```FailIf()``` and ```OkIf()``` you can also write in a more re
 var result = Result.FailIf(string.IsNullOrEmpty(firstName), "First Name is empty");
 ```
 
+If an error instance should be lazily initialized, overloads accepting ```Func<string>``` or ```Func<IError>``` can be used to that effect:
+
+```csharp
+var list = Enumerable.Range(1, 9).ToList();
+
+var result = Result.FailIf(
+    list.Any(IsDivisibleByTen),
+    () => new Error()$"Item {list.First(IsDivisibleByTen)}" should not be on the list));
+
+bool IsDivisibleByTen(int i) => i % 10 == 0;
+
+// rest of the code
+```
+
 ### Try
 
 In some scenarios you want to execute an action. If this action throws an exception then the exception should be catched and transformed to a result object. 

--- a/src/FluentResults.Test/ResultWithoutValueTests.cs
+++ b/src/FluentResults.Test/ResultWithoutValueTests.cs
@@ -229,6 +229,50 @@ namespace FluentResults.Test
         }
 
         [Fact]
+        public void FailIf_FailedConditionIsFalseAndWithObjectErrorFactory_CreateSuccessResult()
+        {
+            var result = Result.FailIf(false, LazyError);
+
+            result.IsFailed.Should().BeFalse();
+
+            Error LazyError()
+            {
+                throw new Exception("This should not be thrown!");
+            }
+        }
+
+        [Fact]
+        public void FailIf_FailedConditionIsFalseAndWithStringErrorMessageFactory_CreateSuccessResult()
+        {
+            var result = Result.FailIf(false, LazyError);
+
+            result.IsFailed.Should().BeFalse();
+
+            string LazyError()
+            {
+                throw new Exception("This should not be thrown!");
+            }
+        }
+
+        [Fact]
+        public void FailIf_FailedConditionIsTrueAndWithObjectErrorFactory_CreateFailedResult()
+        {
+            var result = Result.FailIf(true, () => "Error message");
+
+            result.IsFailed.Should().BeTrue();
+            result.Errors.Single().Message.Should().Be("Error message");
+        }
+
+        [Fact]
+        public void FailIf_FailedConditionIsTrueAndWithStringErrorMessageFactory_CreateFailedResult()
+        {
+            var result = Result.FailIf(true, () => new Error("Error message"));
+
+            result.IsFailed.Should().BeTrue();
+            result.Errors.Single().Message.Should().Be("Error message");
+        }
+
+        [Fact]
         public void OkIf_SuccessConditionIsTrueAndWithStringErrorMessage_CreateFailedResult()
         {
             var result = Result.OkIf(true, "Error message");
@@ -244,6 +288,32 @@ namespace FluentResults.Test
 
             // Assert
             result.IsSuccess.Should().BeTrue();
+        }
+
+        [Fact]
+        public void OkIf_SuccessConditionIsTrueAndWithStringErrorMessageFactory_CreateSuccessResult()
+        {
+            var result = Result.OkIf(true, LazyError);
+
+            result.IsSuccess.Should().BeTrue();
+
+            string LazyError()
+            {
+                throw new Exception("This should not be thrown!");
+            }
+        }
+
+        [Fact]
+        public void OkIf_SuccessConditionIsTrueAnWithObjectErrorMessageFactory_CreateSuccessResult()
+        {
+            var result = Result.OkIf(true, LazyError);
+
+            result.IsSuccess.Should().BeTrue();
+
+            Error LazyError()
+            {
+                throw new Exception("This should not be thrown!");
+            }
         }
 
         [Fact]
@@ -266,6 +336,25 @@ namespace FluentResults.Test
             result.Errors.Single().Message.Should().Be("Error message");
         }
 
+        [Fact]
+        public void OkIf_SuccessConditionIsFalseAndWithStringErrorMessageFactory_CreateFailedResult()
+        {
+            const string errorMessage = "Error message";
+            var result = Result.OkIf(false, () => errorMessage);
+
+            result.IsFailed.Should().BeTrue();
+            result.Errors.Single().Message.Should().Be(errorMessage);
+        }
+
+        [Fact]
+        public void OkIf_SuccessConditionIsFalseAndWithObjectErrorMessageFactory_CreateFailedResult()
+        {
+            const string errorMessage = "Error message";
+            var result = Result.OkIf(false, () => new Error(errorMessage));
+
+            result.IsFailed.Should().BeTrue();
+            result.Errors.Single().Message.Should().Be(errorMessage);
+        }
 
         [Fact]
         public void Try_execute_successfully_action_return_success_result()

--- a/src/FluentResults/Factories/Results.cs
+++ b/src/FluentResults/Factories/Results.cs
@@ -169,6 +169,28 @@ namespace FluentResults
         }
 
         /// <summary>
+        /// Create a success/failed result depending on the parameter isSuccess
+        /// </summary>
+        /// <remarks>
+        /// Error is lazily evaluated.
+        /// </remarks>
+        public static Result OkIf(bool isSuccess, Func<IError> errorFactory)
+        {
+            return isSuccess ? Ok() : Fail(errorFactory.Invoke());
+        }
+
+        /// <summary>
+        /// Create a success/failed result depending on the parameter isSuccess
+        /// </summary>
+        /// <remarks>
+        /// Error is lazily evaluated.
+        /// </remarks>
+        public static Result OkIf(bool isSuccess, Func<string> errorMessageFactory)
+        {
+            return isSuccess ? Ok() : Fail(errorMessageFactory.Invoke());
+        }
+
+        /// <summary>
         /// Create a success/failed result depending on the parameter isFailure
         /// </summary>
         public static Result FailIf(bool isFailure, IError error)
@@ -182,6 +204,28 @@ namespace FluentResults
         public static Result FailIf(bool isFailure, string error)
         {
             return isFailure ? Fail(error) : Ok();
+        }
+
+        /// <summary>
+        /// Create a success/failed result depending on the parameter isFailure
+        /// </summary>
+        /// <remarks>
+        /// Error is lazily evaluated.
+        /// </remarks>
+        public static Result FailIf(bool isFailure, Func<IError> errorFactory)
+        {
+            return isFailure ? Fail(errorFactory.Invoke()) : Ok();
+        }
+
+        /// <summary>
+        /// Create a success/failed result depending on the parameter isFailure
+        /// </summary>
+        /// <remarks>
+        /// Error is lazily evaluated.
+        /// </remarks>
+        public static Result FailIf(bool isFailure, Func<string> errorMessageFactory)
+        {
+            return isFailure ? Fail(errorMessageFactory.Invoke()) : Ok();
         }
 
         /// <summary>


### PR DESCRIPTION
- Implemented lazy error evaluation for `Result.OkIf` and `Result.FailIf` methods (including unit tests).
- Added short description of the feature in the README.

Fixes #141