### PR TITLE
feat: add .Bind operator to map results into a flattened Result

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ Result.Ok<int>(5).ToResult<float>(v => v);
 Result.Fail<int>("Failed").ToResult<float>();
 
 // converting a result to a result from type Result
-Result.Ok<int>().ToResult(); 
+Result.Ok<int>().ToResult();
 ```
 
 ### Implicit conversion from T to success result ```Result<T>```
@@ -335,6 +335,41 @@ Result.Ok<int>().ToResult();
 ```csharp
 string myString = "hello world";
 Result<T> result = myString;
+```
+
+### Bind the result to another result
+
+Binding is a transformation that returns a `Result` | `Result<T>`.
+It only evaluates the transformation if the original result is successful.
+The reasons of both `Result` will be merged into a new flattened `Result`.
+
+```csharp
+// converting a result to a result which may fail
+Result<string> r = Result.Ok(8)
+    .Bind(v => v == 5 ? "five" : Result.Fail<string>("It is not five"));
+
+// converting a failed result to a result, which can also fail, 
+// returns a result with the errors of the first result only,
+// the transformation is not evaluated because the value of the first result is not available
+Result<string> r = Result.Fail<int>("Not available")
+    .Bind(v => v == 5 ? "five" : Result.Fail<string>("It is not five"));
+
+// converting a result with value to a Result via a transformation which may fail
+Result.Ok(5).Bind(x => Result.OkIf(x == 6, "Number is not 6"));
+
+// converting a result without value into a Result 
+Result.Ok().Bind(() => Result.Ok(5));
+
+// just running an action if the original result is sucessful. 
+Result r = Result.Ok().Bind(() => Result.Ok());
+```
+
+The `Bind` has asynchronous overloads.
+
+```csharp
+var result = await Result.Ok(5)
+    .Bind(int n => Task.FromResult(Result.Ok(n + 1).WithSuccess("Added one")))
+    .Bind(int n => /* next continuation */);
 ```
 
 ### Set global factories for ISuccess/IError/IExceptionalError

--- a/src/FluentResults.Test/Playground.cs
+++ b/src/FluentResults.Test/Playground.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
+using FluentResults.Extensions;
 
 namespace FluentResults.Test
 {
@@ -21,31 +23,30 @@ namespace FluentResults.Test
             var voidResult = Result.Ok();
 
             voidResult = Result.Ok()
-                .WithSuccess("This is a success")
-                .WithSuccess("This is a second success");
+                               .WithSuccess("This is a success")
+                               .WithSuccess("This is a second success");
 
             voidResult = Result.Fail("First error");
 
             voidResult = Result.Fail(new Error("First error"));
 
             voidResult = Result.Fail("First error")
-                .WithError("second error")
-                .WithError(new CustomError().CausedBy(new InvalidCastException()));
-
+                               .WithError("second error")
+                               .WithError(new CustomError().CausedBy(new InvalidCastException()));
 
             var valueResult = Result.Ok<int>(default)
-                .WithSuccess("first success")
-                .WithValue(3);
+                                    .WithSuccess("first success")
+                                    .WithValue(3);
 
             valueResult = Result.Ok(3);
 
             valueResult = Result.Ok<int>(default)
-                .WithValue(3);
+                                .WithValue(3);
 
             valueResult = Result.Fail<int>("First error");
 
             valueResult = Result.Fail<int>(new Error("first error"))
-                .WithError("second error");
+                                .WithError("second error");
 
             IEnumerable<Result> results = new List<Result>();
             Result mergedResult = results.Merge();
@@ -89,5 +90,26 @@ namespace FluentResults.Test
             var result1 = Result.Ok();
             result1 = result1.Log();
         }
+
+        public async Task BindTests()
+        {
+            var r = Result.Ok(1);
+
+            var r1 = await r.Bind(v => GetVResult())
+                            .Bind(v => GetVResultAsync())
+                            .Bind(v => GetVResult())
+                            .Bind(v => GetVResultAsync())
+                ;
+
+            var r2 = await r.Bind(v => GetVResultAsync());
+        }
+
+        private Result GetResult() => Result.Ok();
+
+        private Result<int> GetVResult() => Result.Ok(1);
+
+        private Task<Result> GetResultAsync() => Task.FromResult(GetResult());
+
+        private Task<Result<int>> GetVResultAsync() => Task.FromResult(GetVResult());
     }
 }

--- a/src/FluentResults.Test/ResultWithValueTests.cs
+++ b/src/FluentResults.Test/ResultWithValueTests.cs
@@ -278,6 +278,390 @@ namespace FluentResults.Test
             result.Value.Should().Be(4);
         }
 
+        public class BindMethod
+        {
+            [Fact]
+            public void Bind_ToAnotherValueTypeWithFailedResult_ReturnFailedResult()
+            {
+                var valueResult = Result.Fail<int>("First error message");
+
+                // Act
+                var result = valueResult.Bind(Result.Ok);
+
+                // Assert
+                result.IsFailed.Should().BeTrue();
+                result.Errors.Select(e => e.Message)
+                    .Should()
+                    .BeEquivalentTo("First error message");
+            }
+            
+            [Fact]
+            public async Task Bind_ToAnotherValueTypeWithFailedResult_ReturnFailedResultTask()
+            {
+                var valueResult = Result.Fail<int>("First error message");
+
+                // Act
+                var result = await valueResult.Bind(x => Task.FromResult(Result.Ok(x)));
+
+                // Assert
+                result.IsFailed.Should().BeTrue();
+                result.Errors.Select(e => e.Message)
+                    .Should()
+                    .BeEquivalentTo("First error message");
+            }
+            
+            [Fact]
+            public async Task Bind_ToAnotherValueTypeWithFailedResult_ReturnFailedResultValueTask()
+            {
+                var valueResult = Result.Fail<int>("First error message");
+
+                // Act
+                var result = await valueResult.Bind(x => new ValueTask<Result<int>>(Result.Ok(x)));
+
+                // Assert
+                result.IsFailed.Should().BeTrue();
+                result.Errors.Select(e => e.Message)
+                    .Should()
+                    .BeEquivalentTo("First error message");
+            }
+            
+            [Fact]
+            public void Bind_ToResultWithFailedResult_ReturnFailedResult()
+            {
+                var valueResult = Result.Fail<int>("First error message");
+
+                // Act
+                var result = valueResult.Bind(_ => Result.Ok());
+
+                // Assert
+                result.IsFailed.Should().BeTrue();
+                result.Errors.Select(e => e.Message)
+                    .Should()
+                    .BeEquivalentTo("First error message");
+            }
+            
+            [Fact]
+            public async Task Bind_ToResultWithFailedResult_ReturnFailedResultTask()
+            {
+                var valueResult = Result.Fail<int>("First error message");
+
+                // Act
+                var result = await valueResult.Bind(_ => Task.FromResult(Result.Ok()));
+
+                // Assert
+                result.IsFailed.Should().BeTrue();
+                result.Errors.Select(e => e.Message)
+                    .Should()
+                    .BeEquivalentTo("First error message");
+            }
+            
+            [Fact]
+            public async Task Bind_ToResultWithFailedResult_ReturnFailedResultValueTask()
+            {
+                var valueResult = Result.Fail<int>("First error message");
+
+                // Act
+                var result = await valueResult.Bind(_ => new ValueTask<Result>(Result.Ok()));
+
+                // Assert
+                result.IsFailed.Should().BeTrue();
+                result.Errors.Select(e => e.Message)
+                    .Should()
+                    .BeEquivalentTo("First error message");
+            }
+            
+            [Fact]
+            public void Bind_ToAnotherValueTypeWithFailedResultAndFailedTransformation_ReturnFailedResult()
+            {
+                var valueResult = Result.Fail<int>("Original error message");
+
+                // Act
+                var result = valueResult.Bind(_ => Result.Fail<string>("Irrelevant error"));
+
+                // Assert
+                result.IsFailed.Should().BeTrue();
+                result.Errors.Select(e => e.Message)
+                    .Should()
+                    .BeEquivalentTo("Original error message");
+            }
+            
+            [Fact]
+            public async Task Bind_ToAnotherValueTypeWithFailedResultAndFailedTransformation_ReturnFailedResultTask()
+            {
+                var valueResult = Result.Fail<int>("Original error message");
+
+                // Act
+                var result = await valueResult.Bind(_ => Task.FromResult(Result.Fail<string>("Irrelevant error")));
+
+                // Assert
+                result.IsFailed.Should().BeTrue();
+                result.Errors.Select(e => e.Message)
+                    .Should()
+                    .BeEquivalentTo("Original error message");
+            }
+            
+            [Fact]
+            public async Task Bind_ToAnotherValueTypeWithFailedResultAndFailedTransformation_ReturnFailedResultValueTask()
+            {
+                var valueResult = Result.Fail<int>("Original error message");
+
+                // Act
+                var result = await valueResult.Bind(_ => Task.FromResult(Result.Fail<string>("Irrelevant error")));
+
+                // Assert
+                result.IsFailed.Should().BeTrue();
+                result.Errors.Select(e => e.Message)
+                    .Should()
+                    .BeEquivalentTo("Original error message");
+            }
+            
+            [Fact]
+            public void Bind_ToResultWithFailedResultAndFailedTransformation_ReturnFailedResult()
+            {
+                var valueResult = Result.Fail<int>("Original error message");
+
+                // Act
+                var result = valueResult.Bind(_ => Result.Fail("Irrelevant error"));
+
+                // Assert
+                result.IsFailed.Should().BeTrue();
+                result.Errors.Select(e => e.Message)
+                    .Should()
+                    .BeEquivalentTo("Original error message");
+            }
+            
+            [Fact]
+            public async Task Bind_ToResultWithFailedResultAndFailedTransformation_ReturnFailedResultTask()
+            {
+                var valueResult = Result.Fail<int>("Original error message");
+
+                // Act
+                var result = await valueResult.Bind(_ => Task.FromResult(Result.Fail("Irrelevant error")));
+
+                // Assert
+                result.IsFailed.Should().BeTrue();
+                result.Errors.Select(e => e.Message)
+                    .Should()
+                    .BeEquivalentTo("Original error message");
+            }
+            
+            [Fact]
+            public async Task Bind_ToResultWithFailedResultAndFailedTransformation_ReturnFailedResultValueTask()
+            {
+                var valueResult = Result.Fail<int>("Original error message");
+
+                // Act
+                var result = await valueResult.Bind(_ => new ValueTask<Result>(Result.Fail("Irrelevant error")));
+
+                // Assert
+                result.IsFailed.Should().BeTrue();
+                result.Errors.Select(e => e.Message)
+                    .Should()
+                    .BeEquivalentTo("Original error message");
+            }
+
+            [Fact]
+            public void Bind_ToAnotherValueTypeWhichIsSuccessful_ReturnsSuccessResult()
+            {
+                var valueResult = Result.Ok(1).WithSuccess("An int");
+
+                // Act
+                var result = valueResult.Bind(n => n == 1 
+                    ? "One".ToResult().WithSuccess("It is one") 
+                    : Result.Fail<string>("Only one accepted"));
+
+                // Assert
+                result.IsSuccess.Should().BeTrue();
+                result.Value.Should()
+                    .Be("One");
+
+                result.Successes.Select(s => s.Message)
+                    .Should()
+                    .BeEquivalentTo("An int", "It is one");
+            }
+            
+            [Fact]
+            public async Task Bind_ToAnotherValueTypeWhichIsSuccessful_ReturnsSuccessResultTask()
+            {
+                var valueResult = Result.Ok(1).WithSuccess("An int");
+
+                // Act
+                var result = await valueResult.Bind(n => Task.FromResult(n == 1 
+                    ? "One".ToResult().WithSuccess("It is one") 
+                    : Result.Fail<string>("Only one accepted")));
+
+                // Assert
+                result.IsSuccess.Should().BeTrue();
+                result.Value.Should()
+                    .Be("One");
+
+                result.Successes.Select(s => s.Message)
+                    .Should()
+                    .BeEquivalentTo("An int", "It is one");
+            }
+            
+            [Fact]
+            public async Task Bind_ToAnotherValueTypeWhichIsSuccessful_ReturnsSuccessResultValueTask()
+            {
+                var valueResult = Result.Ok(1).WithSuccess("An int");
+
+                // Act
+                var result = await valueResult.Bind(n => new ValueTask<Result<string>>(n == 1 
+                    ? "One".ToResult().WithSuccess("It is one") 
+                    : Result.Fail<string>("Only one accepted")));
+
+                // Assert
+                result.IsSuccess.Should().BeTrue();
+                result.Value.Should()
+                    .Be("One");
+
+                result.Successes.Select(s => s.Message)
+                    .Should()
+                    .BeEquivalentTo("An int", "It is one");
+            }
+            
+            [Fact]
+            public void Bind_ToResultWhichIsSuccessful_ReturnsSuccessResult()
+            {
+                var valueResult = Result.Ok(1).WithSuccess("First number");
+
+                // Act
+                var result = valueResult.Bind(n => Result.OkIf(n == 1, "Irrelevant").WithSuccess("It is one"));
+
+                // Assert
+                result.IsSuccess.Should().BeTrue();
+                result.Successes.Select(s => s.Message)
+                    .Should()
+                    .BeEquivalentTo("First number", "It is one");
+            }
+            
+            [Fact]
+            public async Task Bind_ToResultWhichIsSuccessful_ReturnsSuccessResultTask()
+            {
+                var valueResult = Result.Ok(1).WithSuccess("First number");
+
+                // Act
+                var result = await valueResult.Bind(n => Task.FromResult(Result.OkIf(n == 1, "Irrelevant").WithSuccess("It is one")));
+
+                // Assert
+                result.IsSuccess.Should().BeTrue();
+                result.Successes.Select(s => s.Message)
+                    .Should()
+                    .BeEquivalentTo("First number", "It is one");
+            }
+            
+            [Fact]
+            public async Task Bind_ToResultWhichIsSuccessful_ReturnsSuccessResultValueTask()
+            {
+                var valueResult = Result.Ok(1).WithSuccess("First number");
+
+                // Act
+                var result = await valueResult.Bind(n => new ValueTask<Result<string>>(Result.OkIf(n == 1, "Irrelevant").WithSuccess("It is one")));
+
+                // Assert
+                result.IsSuccess.Should().BeTrue();
+                result.Successes.Select(s => s.Message)
+                    .Should()
+                    .BeEquivalentTo("First number", "It is one");
+            }
+            
+            [Fact]
+            public void Bind_ToAnotherValueTypeWhichFailedTransformation_ReturnsFailedResult()
+            {
+                var valueResult = Result.Ok(5);
+
+                // Act
+                var result = valueResult.Bind(n => Result.Fail<string>("Only one accepted"));
+
+                // Assert
+                result.IsFailed.Should().BeTrue();
+
+                result.Errors.Select(s => s.Message)
+                    .Should()
+                    .BeEquivalentTo("Only one accepted");
+            }
+            
+            [Fact]
+            public async Task Bind_ToAnotherValueTypeWhichFailedTransformation_ReturnsFailedResultTask()
+            {
+                var valueResult = Result.Ok(5);
+
+                // Act
+                var result = await valueResult.Bind(n => Task.FromResult(Result.Fail<string>("Only one accepted")));
+
+                // Assert
+                result.IsFailed.Should().BeTrue();
+
+                result.Errors.Select(s => s.Message)
+                    .Should()
+                    .BeEquivalentTo("Only one accepted");
+            }
+            
+            [Fact]
+            public async Task Bind_ToAnotherValueTypeWhichFailedTransformation_ReturnsFailedResultValueTask()
+            {
+                var valueResult = Result.Ok(5);
+
+                // Act
+                var result = await valueResult.Bind(n => new ValueTask<Result<string>>(Result.Fail<string>("Only one accepted")));
+
+                // Assert
+                result.IsFailed.Should().BeTrue();
+
+                result.Errors.Select(s => s.Message)
+                    .Should()
+                    .BeEquivalentTo("Only one accepted");
+            }
+            
+            [Fact]
+            public void Bind_ToResultWhichFailedTransformation_ReturnsFailedResult()
+            {
+                var valueResult = Result.Ok(5);
+
+                // Act
+                var result = valueResult.Bind(n => Result.Fail("Only one accepted"));
+
+                // Assert
+                result.IsFailed.Should().BeTrue();
+
+                result.Errors.Select(s => s.Message)
+                    .Should()
+                    .BeEquivalentTo("Only one accepted");
+            }
+            
+            [Fact]
+            public async Task Bind_ToResultWhichFailedTransformation_ReturnsFailedResultTask()
+            {
+                var valueResult = Result.Ok(5);
+
+                // Act
+                var result = await valueResult.Bind(n => Task.FromResult(Result.Fail("Only one accepted")));
+
+                // Assert
+                result.IsFailed.Should().BeTrue();
+
+                result.Errors.Select(s => s.Message)
+                    .Should()
+                    .BeEquivalentTo("Only one accepted");
+            }
+            
+            [Fact]
+            public async Task Bind_ToResultWhichFailedTransformation_ReturnsFailedResultValueTask()
+            {
+                var valueResult = Result.Ok(5);
+
+                // Act
+                var result = await valueResult.Bind(n => new ValueTask<Result<string>>(Result.Fail("Only one accepted")));
+
+                // Assert
+                result.IsFailed.Should().BeTrue();
+
+                result.Errors.Select(s => s.Message)
+                    .Should()
+                    .BeEquivalentTo("Only one accepted");
+            }
+        }
+
         [Fact]
         public void ImplicitCastOperator_ReturnFailedResult()
         {

--- a/src/FluentResults.Test/ResultWithoutValueTests.cs
+++ b/src/FluentResults.Test/ResultWithoutValueTests.cs
@@ -526,5 +526,383 @@ namespace FluentResults.Test
             errors.Count.Should().Be(1);
             errors.FirstOrDefault().Should().Be(error);
         }
+
+        public class BindMethod
+        {
+            [Fact]
+            public void Bind_ToAnotherValueTypeWithFailedResult_ReturnFailedResult()
+            {
+                var valueResult = Result.Fail("First error message");
+
+                // Act
+                var result = valueResult.Bind(() => Result.Ok(1));
+
+                // Assert
+                result.IsFailed.Should().BeTrue();
+                result.Errors.Select(e => e.Message)
+                    .Should()
+                    .BeEquivalentTo("First error message");
+            }
+            
+            [Fact]
+            public async Task Bind_ToAnotherValueTypeWithFailedResult_ReturnFailedResultTask()
+            {
+                var valueResult = Result.Fail("First error message");
+
+                // Act
+                var result = await valueResult.Bind(() => Task.FromResult(Result.Ok(1)));
+
+                // Assert
+                result.IsFailed.Should().BeTrue();
+                result.Errors.Select(e => e.Message)
+                    .Should()
+                    .BeEquivalentTo("First error message");
+            }
+            
+            [Fact]
+            public async Task Bind_ToAnotherValueTypeWithFailedResult_ReturnFailedResultValueTask()
+            {
+                var valueResult = Result.Fail("First error message");
+
+                // Act
+                var result = await valueResult.Bind(() => new ValueTask<Result<int>>(Result.Ok(1)));
+
+                // Assert
+                result.IsFailed.Should().BeTrue();
+                result.Errors.Select(e => e.Message)
+                    .Should()
+                    .BeEquivalentTo("First error message");
+            }
+            
+            [Fact]
+            public void Bind_ToResultWithFailedResult_ReturnFailedResult()
+            {
+                var valueResult = Result.Fail("First error message");
+
+                // Act
+                var result = valueResult.Bind(Result.Ok);
+
+                // Assert
+                result.IsFailed.Should().BeTrue();
+                result.Errors.Select(e => e.Message)
+                    .Should()
+                    .BeEquivalentTo("First error message");
+            }
+            
+            [Fact]
+            public async Task Bind_ToResultWithFailedResult_ReturnFailedResultTask()
+            {
+                var valueResult = Result.Fail("First error message");
+
+                // Act
+                var result = await valueResult.Bind(() => Task.FromResult(Result.Ok()));
+
+                // Assert
+                result.IsFailed.Should().BeTrue();
+                result.Errors.Select(e => e.Message)
+                    .Should()
+                    .BeEquivalentTo("First error message");
+            }
+            
+            [Fact]
+            public async Task Bind_ToResultWithFailedResult_ReturnFailedResultValueTask()
+            {
+                var valueResult = Result.Fail("First error message");
+
+                // Act
+                var result = await valueResult.Bind(() => new ValueTask<Result>(Result.Ok()));
+
+                // Assert
+                result.IsFailed.Should().BeTrue();
+                result.Errors.Select(e => e.Message)
+                    .Should()
+                    .BeEquivalentTo("First error message");
+            }
+            
+            [Fact]
+            public void Bind_ToAnotherValueTypeWithFailedResultAndFailedTransformation_ReturnFailedResult()
+            {
+                var valueResult = Result.Fail("Original error message");
+
+                // Act
+                var result = valueResult.Bind(() => Result.Fail<string>("Irrelevant error"));
+
+                // Assert
+                result.IsFailed.Should().BeTrue();
+                result.Errors.Select(e => e.Message)
+                    .Should()
+                    .BeEquivalentTo("Original error message");
+            }
+            
+            [Fact]
+            public async Task Bind_ToAnotherValueTypeWithFailedResultAndFailedTransformation_ReturnFailedResultTask()
+            {
+                var valueResult = Result.Fail("Original error message");
+
+                // Act
+                var result = await valueResult.Bind(() => Task.FromResult(Result.Fail<string>("Irrelevant error")));
+
+                // Assert
+                result.IsFailed.Should().BeTrue();
+                result.Errors.Select(e => e.Message)
+                    .Should()
+                    .BeEquivalentTo("Original error message");
+            }
+            
+            [Fact]
+            public async Task Bind_ToAnotherValueTypeWithFailedResultAndFailedTransformation_ReturnFailedResultValueTask()
+            {
+                var valueResult = Result.Fail("Original error message");
+
+                // Act
+                var result = await valueResult.Bind(() => Task.FromResult(Result.Fail<string>("Irrelevant error")));
+
+                // Assert
+                result.IsFailed.Should().BeTrue();
+                result.Errors.Select(e => e.Message)
+                    .Should()
+                    .BeEquivalentTo("Original error message");
+            }
+            
+            [Fact]
+            public void Bind_ToResultWithFailedResultAndFailedTransformation_ReturnFailedResult()
+            {
+                var valueResult = Result.Fail("Original error message");
+
+                // Act
+                var result = valueResult.Bind(() => Result.Fail("Irrelevant error"));
+
+                // Assert
+                result.IsFailed.Should().BeTrue();
+                result.Errors.Select(e => e.Message)
+                    .Should()
+                    .BeEquivalentTo("Original error message");
+            }
+            
+            [Fact]
+            public async Task Bind_ToResultWithFailedResultAndFailedTransformation_ReturnFailedResultTask()
+            {
+                var valueResult = Result.Fail("Original error message");
+
+                // Act
+                var result = await valueResult.Bind(() => Task.FromResult(Result.Fail("Irrelevant error")));
+
+                // Assert
+                result.IsFailed.Should().BeTrue();
+                result.Errors.Select(e => e.Message)
+                    .Should()
+                    .BeEquivalentTo("Original error message");
+            }
+            
+            [Fact]
+            public async Task Bind_ToResultWithFailedResultAndFailedTransformation_ReturnFailedResultValueTask()
+            {
+                var valueResult = Result.Fail("Original error message");
+
+                // Act
+                var result = await valueResult.Bind(() => new ValueTask<Result>(Result.Fail("Irrelevant error")));
+
+                // Assert
+                result.IsFailed.Should().BeTrue();
+                result.Errors.Select(e => e.Message)
+                    .Should()
+                    .BeEquivalentTo("Original error message");
+            }
+
+            [Fact]
+            public void Bind_ToAnotherValueTypeWhichIsSuccessful_ReturnsSuccessResult()
+            {
+                var valueResult = Result.Ok().WithSuccess("An int");
+
+                // Act
+                var result = valueResult.Bind(() => "One".ToResult().WithSuccess("It is one"));
+
+                // Assert
+                result.IsSuccess.Should().BeTrue();
+                result.Value.Should()
+                    .Be("One");
+
+                result.Successes.Select(s => s.Message)
+                    .Should()
+                    .BeEquivalentTo("An int", "It is one");
+            }
+            
+            [Fact]
+            public async Task Bind_ToAnotherValueTypeWhichIsSuccessful_ReturnsSuccessResultTask()
+            {
+                var valueResult = Result.Ok().WithSuccess("An int");
+
+                // Act
+                var result = await valueResult.Bind(() => Task.FromResult("One".ToResult().WithSuccess("It is one")));
+
+                // Assert
+                result.IsSuccess.Should().BeTrue();
+                result.Value.Should()
+                    .Be("One");
+
+                result.Successes.Select(s => s.Message)
+                    .Should()
+                    .BeEquivalentTo("An int", "It is one");
+            }
+            
+            [Fact]
+            public async Task Bind_ToAnotherValueTypeWhichIsSuccessful_ReturnsSuccessResultValueTask()
+            {
+                var valueResult = Result.Ok().WithSuccess("An int");
+
+                // Act
+                var result = await valueResult.Bind(() => new ValueTask<Result<string>>("One".ToResult().WithSuccess("It is one")));
+
+                // Assert
+                result.IsSuccess.Should().BeTrue();
+                result.Value.Should()
+                    .Be("One");
+
+                result.Successes.Select(s => s.Message)
+                    .Should()
+                    .BeEquivalentTo("An int", "It is one");
+            }
+            
+            [Fact]
+            public void Bind_ToResultWhichIsSuccessful_ReturnsSuccessResult()
+            {
+                var valueResult = Result.Ok().WithSuccess("First number");
+
+                // Act
+                var result = valueResult.Bind(() => Result.Ok().WithSuccess("It is one"));
+
+                // Assert
+                result.IsSuccess.Should().BeTrue();
+                result.Successes.Select(s => s.Message)
+                    .Should()
+                    .BeEquivalentTo("First number", "It is one");
+            }
+            
+            [Fact]
+            public async Task Bind_ToResultWhichIsSuccessful_ReturnsSuccessResultTask()
+            {
+                var valueResult = Result.Ok().WithSuccess("First number");
+
+                // Act
+                var result = await valueResult.Bind(() => Task.FromResult(Result.Ok().WithSuccess("It is one")));
+
+                // Assert
+                result.IsSuccess.Should().BeTrue();
+                result.Successes.Select(s => s.Message)
+                    .Should()
+                    .BeEquivalentTo("First number", "It is one");
+            }
+            
+            [Fact]
+            public async Task Bind_ToResultWhichIsSuccessful_ReturnsSuccessResultValueTask()
+            {
+                var valueResult = Result.Ok().WithSuccess("First number");
+
+                // Act
+                var result = await valueResult.Bind(() => new ValueTask<Result<string>>(Result.Ok().WithSuccess("It is one")));
+
+                // Assert
+                result.IsSuccess.Should().BeTrue();
+                result.Successes.Select(s => s.Message)
+                    .Should()
+                    .BeEquivalentTo("First number", "It is one");
+            }
+            
+            [Fact]
+            public void Bind_ToAnotherValueTypeWhichFailedTransformation_ReturnsFailedResult()
+            {
+                var valueResult = Result.Ok();
+
+                // Act
+                var result = valueResult.Bind(() => Result.Fail<string>("Only one accepted"));
+
+                // Assert
+                result.IsFailed.Should().BeTrue();
+
+                result.Errors.Select(s => s.Message)
+                    .Should()
+                    .BeEquivalentTo("Only one accepted");
+            }
+            
+            [Fact]
+            public async Task Bind_ToAnotherValueTypeWhichFailedTransformation_ReturnsFailedResultTask()
+            {
+                var valueResult = Result.Ok();
+
+                // Act
+                var result = await valueResult.Bind(() => Task.FromResult(Result.Fail<string>("Only one accepted")));
+
+                // Assert
+                result.IsFailed.Should().BeTrue();
+
+                result.Errors.Select(s => s.Message)
+                    .Should()
+                    .BeEquivalentTo("Only one accepted");
+            }
+            
+            [Fact]
+            public async Task Bind_ToAnotherValueTypeWhichFailedTransformation_ReturnsFailedResultValueTask()
+            {
+                var valueResult = Result.Ok();
+
+                // Act
+                var result = await valueResult.Bind(() => new ValueTask<Result<string>>(Result.Fail<string>("Only one accepted")));
+
+                // Assert
+                result.IsFailed.Should().BeTrue();
+
+                result.Errors.Select(s => s.Message)
+                    .Should()
+                    .BeEquivalentTo("Only one accepted");
+            }
+            
+            [Fact]
+            public void Bind_ToResultWhichFailedTransformation_ReturnsFailedResult()
+            {
+                var valueResult = Result.Ok();
+
+                // Act
+                var result = valueResult.Bind(() => Result.Fail("Only one accepted"));
+
+                // Assert
+                result.IsFailed.Should().BeTrue();
+
+                result.Errors.Select(s => s.Message)
+                    .Should()
+                    .BeEquivalentTo("Only one accepted");
+            }
+            
+            [Fact]
+            public async Task Bind_ToResultWhichFailedTransformation_ReturnsFailedResultTask()
+            {
+                var valueResult = Result.Ok();
+
+                // Act
+                var result = await valueResult.Bind(() => Task.FromResult(Result.Fail("Only one accepted")));
+
+                // Assert
+                result.IsFailed.Should().BeTrue();
+
+                result.Errors.Select(s => s.Message)
+                    .Should()
+                    .BeEquivalentTo("Only one accepted");
+            }
+            
+            [Fact]
+            public async Task Bind_ToResultWhichFailedTransformation_ReturnsFailedResultValueTask()
+            {
+                var valueResult = Result.Ok();
+
+                // Act
+                var result = await valueResult.Bind(() => new ValueTask<Result<string>>(Result.Fail("Only one accepted")));
+
+                // Assert
+                result.IsFailed.Should().BeTrue();
+
+                result.Errors.Select(s => s.Message)
+                    .Should()
+                    .BeEquivalentTo("Only one accepted");
+            }
+        }
     }
 }

--- a/src/FluentResults/Extensions/ResultExtensions.cs
+++ b/src/FluentResults/Extensions/ResultExtensions.cs
@@ -64,13 +64,37 @@ namespace FluentResults.Extensions
             var result = await resultTask;
             return await result.Bind(bind);
         }
-        
+
+        public static async Task<Result<TNew>> Bind<TOld, TNew>(this Task<Result<TOld>> resultTask, Func<TOld, Result<TNew>> bind)
+        {
+            var result = await resultTask;
+            return result.Bind(bind);
+        }
+
+        public static async ValueTask<Result<TNew>> Bind<TOld, TNew>(this ValueTask<Result<TOld>> resultTask, Func<TOld, Result<TNew>> bind)
+        {
+            var result = await resultTask;
+            return result.Bind(bind);
+        }
+
         public static async Task<Result> Bind<TOld>(this Task<Result<TOld>> resultTask, Func<TOld, Task<Result>> bind)
         {
             var result = await resultTask;
             return await result.Bind(bind);
         }
-        
+
+        public static async Task<Result> Bind<TOld>(this Task<Result<TOld>> resultTask, Func<TOld, Result> bind)
+        {
+            var result = await resultTask;
+            return result.Bind(bind);
+        }
+
+        public static async ValueTask<Result> Bind<TOld>(this ValueTask<Result<TOld>> resultTask, Func<TOld, Result> bind)
+        {
+            var result = await resultTask;
+            return result.Bind(bind);
+        }
+
         public static async ValueTask<Result> Bind<TOld>(this ValueTask<Result<TOld>> resultTask, Func<TOld, ValueTask<Result>> bind)
         {
             var result = await resultTask;

--- a/src/FluentResults/Extensions/ResultExtensions.cs
+++ b/src/FluentResults/Extensions/ResultExtensions.cs
@@ -52,5 +52,53 @@ namespace FluentResults.Extensions
             var result = await resultTask;
             return result.MapSuccesses(errorMapper);
         }
+
+        public static async Task<Result<TNew>> Bind<TOld, TNew>(this Task<Result<TOld>> resultTask, Func<TOld, Task<Result<TNew>>> bind)
+        {
+            var result = await resultTask;
+            return await result.Bind(bind);
+        }
+        
+        public static async ValueTask<Result<TNew>> Bind<TOld, TNew>(this ValueTask<Result<TOld>> resultTask, Func<TOld, ValueTask<Result<TNew>>> bind)
+        {
+            var result = await resultTask;
+            return await result.Bind(bind);
+        }
+        
+        public static async Task<Result> Bind<TOld>(this Task<Result<TOld>> resultTask, Func<TOld, Task<Result>> bind)
+        {
+            var result = await resultTask;
+            return await result.Bind(bind);
+        }
+        
+        public static async ValueTask<Result> Bind<TOld>(this ValueTask<Result<TOld>> resultTask, Func<TOld, ValueTask<Result>> bind)
+        {
+            var result = await resultTask;
+            return await result.Bind(bind);
+        }
+        
+        public static async Task<Result<TNew>> Bind<TNew>(this Task<Result> resultTask, Func<Task<Result<TNew>>> bind)
+        {
+            var result = await resultTask;
+            return await result.Bind(bind);
+        }
+        
+        public static async ValueTask<Result<TNew>> Bind<TNew>(this ValueTask<Result> resultTask, Func<ValueTask<Result<TNew>>> bind)
+        {
+            var result = await resultTask;
+            return await result.Bind(bind);
+        }
+        
+        public static async Task<Result> Bind(this Task<Result> resultTask, Func<Task<Result>> bind)
+        {
+            var result = await resultTask;
+            return await result.Bind(bind);
+        }
+        
+        public static async ValueTask<Result> Bind(this ValueTask<Result> resultTask, Func<ValueTask<Result>> bind)
+        {
+            var result = await resultTask;
+            return await result.Bind(bind);
+        }
     }
 }

--- a/src/FluentResults/Results/Result.cs
+++ b/src/FluentResults/Results/Result.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 // ReSharper disable once CheckNamespace
 namespace FluentResults
@@ -19,7 +20,7 @@ namespace FluentResults
         {
             if (IsSuccess)
                 return this;
-            
+
             return new Result()
                 .WithErrors(Errors.Select(errorMapper))
                 .WithSuccesses(Successes);
@@ -42,6 +43,147 @@ namespace FluentResults
             return new Result<TNewValue>()
                 .WithValue(IsFailed ? default : newValue)
                 .WithReasons(Reasons);
+        }
+
+        /// <summary>
+        /// Convert result to result with value that may fail.
+        /// </summary>
+        /// <example>
+        /// <code>
+        ///  var bakeryDtoResult = result.Bind(GetWhichMayFail);
+        /// </code>
+        /// </example>
+        /// <param name="bind">Transformation that may fail.</param>
+        public Result<TNewValue> Bind<TNewValue>(Func<Result<TNewValue>> bind)
+        {
+            var result = new Result<TNewValue>();
+            result.WithReasons(Reasons);
+            
+            if (IsSuccess)
+            {
+                var converted = bind();
+                result.WithValue(converted.ValueOrDefault);
+                result.WithReasons(converted.Reasons);
+            }
+
+            return result;
+        }
+        
+        /// <summary>
+        /// Convert result to result with value that may fail asynchronously.
+        /// </summary>
+        /// <example>
+        /// <code>
+        ///  var bakeryDtoResult = result.Bind(GetWhichMayFail);
+        /// </code>
+        /// </example>
+        /// <param name="bind">Transformation that may fail.</param>
+        public async Task<Result<TNewValue>> Bind<TNewValue>(Func<Task<Result<TNewValue>>> bind)
+        {
+            var result = new Result<TNewValue>();
+            result.WithReasons(Reasons);
+            
+            if (IsSuccess)
+            {
+                var converted = await bind();
+                result.WithValue(converted.ValueOrDefault);
+                result.WithReasons(converted.Reasons);
+            }
+
+            return result;
+        }
+        
+        /// <summary>
+        /// Convert result to result with value that may fail asynchronously.
+        /// </summary>
+        /// <example>
+        /// <code>
+        ///  var bakeryDtoResult = result.Bind(GetWhichMayFail);
+        /// </code>
+        /// </example>
+        /// <param name="bind">Transformation that may fail.</param>
+        public async ValueTask<Result<TNewValue>> Bind<TNewValue>(Func<ValueTask<Result<TNewValue>>> bind)
+        {
+            var result = new Result<TNewValue>();
+            result.WithReasons(Reasons);
+            
+            if (IsSuccess)
+            {
+                var converted = await bind();
+                result.WithValue(converted.ValueOrDefault);
+                result.WithReasons(converted.Reasons);
+            }
+
+            return result;
+        }
+        
+        /// <summary>
+        /// Execute an action which returns a <see cref="Result"/>.
+        /// </summary>
+        /// <example>
+        /// <code>
+        ///  var done = result.Bind(ActionWhichMayFail);
+        /// </code>
+        /// </example>
+        /// <param name="action">Action that may fail.</param>
+        public Result Bind(Func<Result> action)
+        {
+            var result = new Result();
+            result.WithReasons(Reasons);
+            
+            if (IsSuccess)
+            {
+                var converted = action();
+                result.WithReasons(converted.Reasons);
+            }
+
+            return result;
+        }
+        
+        /// <summary>
+        /// Execute an action which returns a <see cref="Result"/> asynchronously.
+        /// </summary>
+        /// <example>
+        /// <code>
+        ///  var done = result.Bind(ActionWhichMayFail);
+        /// </code>
+        /// </example>
+        /// <param name="action">Action that may fail.</param>
+        public async Task<Result> Bind(Func<Task<Result>> action)
+        {
+            var result = new Result();
+            result.WithReasons(Reasons);
+            
+            if (IsSuccess)
+            {
+                var converted = await action();
+                result.WithReasons(converted.Reasons);
+            }
+
+            return result;
+        }
+        
+        /// <summary>
+        /// Execute an action which returns a <see cref="Result"/> asynchronously.
+        /// </summary>
+        /// <example>
+        /// <code>
+        ///  var done = result.Bind(ActionWhichMayFail);
+        /// </code>
+        /// </example>
+        /// <param name="action">Action that may fail.</param>
+        public async ValueTask<Result> Bind(Func<ValueTask<Result>> action)
+        {
+            var result = new Result();
+            result.WithReasons(Reasons);
+            
+            if (IsSuccess)
+            {
+                var converted = await action();
+                result.WithReasons(converted.Reasons);
+            }
+
+            return result;
         }
     }
 
@@ -148,6 +290,150 @@ namespace FluentResults
                 .WithReasons(Reasons);
         }
 
+        /// <summary>
+        /// Convert result with value to result with another value that may fail.
+        /// </summary>
+        /// <example>
+        /// <code>
+        ///  var bakeryDtoResult = result
+        ///     .Bind(GetWhichMayFail)
+        ///     .Bind(ProcessWhichMayFail)
+        ///     .Bind(FormattingWhichMayFail);
+        /// </code>
+        /// </example>
+        /// <param name="bind">Transformation that may fail.</param>
+        public Result<TNewValue> Bind<TNewValue>(Func<TValue, Result<TNewValue>> bind)
+        {
+            var result = new Result<TNewValue>();
+            result.WithReasons(Reasons);
+            
+            if (IsSuccess)
+            {
+                var converted = bind(Value);
+                result.WithValue(converted.ValueOrDefault);
+                result.WithReasons(converted.Reasons);
+            }
+
+            return result;
+        }
+        
+        /// <summary>
+        /// Convert result with value to result with another value that may fail asynchronously.
+        /// </summary>
+        /// <example>
+        /// <code>
+        ///  var bakeryDtoResult = await result.Bind(GetWhichMayFail);
+        /// </code>
+        /// </example>
+        /// <param name="bind">Transformation that may fail.</param>
+        public async Task<Result<TNewValue>> Bind<TNewValue>(Func<TValue, Task<Result<TNewValue>>> bind)
+        {
+            var result = new Result<TNewValue>();
+            result.WithReasons(Reasons);
+            
+            if (IsSuccess)
+            {
+                var converted = await bind(Value);
+                result.WithValue(converted.ValueOrDefault);
+                result.WithReasons(converted.Reasons);
+            }
+
+            return result;
+        }
+        
+        /// <summary>
+        /// Convert result with value to result with another value that may fail asynchronously.
+        /// </summary>
+        /// <example>
+        /// <code>
+        ///  var bakeryDtoResult = await result.Bind(GetWhichMayFail);
+        /// </code>
+        /// </example>
+        /// <param name="bind">Transformation that may fail.</param>
+        public async ValueTask<Result<TNewValue>> Bind<TNewValue>(Func<TValue, ValueTask<Result<TNewValue>>> bind)
+        {
+            var result = new Result<TNewValue>();
+            result.WithReasons(Reasons);
+            
+            if (IsSuccess)
+            {
+                var converted = await bind(Value);
+                result.WithValue(converted.ValueOrDefault);
+                result.WithReasons(converted.Reasons);
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Execute an action which returns a <see cref="Result"/>.
+        /// </summary>
+        /// <example>
+        /// <code>
+        ///  var done = result.Bind(ActionWhichMayFail);
+        /// </code>
+        /// </example>
+        /// <param name="action">Action that may fail.</param>
+        public Result Bind(Func<TValue, Result> action)
+        {
+            var result = new Result();
+            result.WithReasons(Reasons);
+
+            if (IsSuccess)
+            {
+                var converted = action(Value);
+                result.WithReasons(converted.Reasons);
+            }
+
+            return result;
+        }
+        
+        /// <summary>
+        /// Execute an action which returns a <see cref="Result"/> asynchronously.
+        /// </summary>
+        /// <example>
+        /// <code>
+        ///  var done = await result.Bind(ActionWhichMayFail);
+        /// </code>
+        /// </example>
+        /// <param name="action">Action that may fail.</param>
+        public async Task<Result> Bind(Func<TValue, Task<Result>> action)
+        {
+            var result = new Result();
+            result.WithReasons(Reasons);
+
+            if (IsSuccess)
+            {
+                var converted = await action(Value);
+                result.WithReasons(converted.Reasons);
+            }
+
+            return result;
+        }
+        
+        /// <summary>
+        /// Execute an action which returns a <see cref="Result"/> asynchronously.
+        /// </summary>
+        /// <example>
+        /// <code>
+        ///  var done = await result.Bind(ActionWhichMayFail);
+        /// </code>
+        /// </example>
+        /// <param name="action">Action that may fail.</param>
+        public async ValueTask<Result> Bind(Func<TValue, ValueTask<Result>> action)
+        {
+            var result = new Result();
+            result.WithReasons(Reasons);
+
+            if (IsSuccess)
+            {
+                var converted = await action(Value);
+                result.WithReasons(converted.Reasons);
+            }
+
+            return result;
+        }
+
         public override string ToString()
         {
             var baseString = base.ToString();
@@ -180,6 +466,7 @@ namespace FluentResults
             isFailed = IsFailed;
             value = IsSuccess ? Value : default;
         }
+
         /// <summary>
         /// Deconstruct Result
         /// </summary>
@@ -194,7 +481,7 @@ namespace FluentResults
             value = IsSuccess ? Value : default;
             errors = IsFailed ? Errors : default;
         }
-        
+
         private void ThrowIfFailed()
         {
             if (IsFailed)


### PR DESCRIPTION
Related to the issues #140 and #108.

This will allow Kleiski compositions (`Result<A>, A -> Result<B>, B -> Result<C>,...`), eliminating the need of using statements to compose the results manually.