### PR TITLE
Implicit operators for failed Result<T>

### DIFF
--- a/src/FluentResults.Test/ErrorTests.cs
+++ b/src/FluentResults.Test/ErrorTests.cs
@@ -156,5 +156,35 @@ namespace FluentResults.Test
             result.Reasons[0].Message.Should().Be("First error message");
             result.Reasons[1].Message.Should().Be("Second error message");
         }
+        
+        [Fact]
+        public void CreateErrorOfT_FromErrorImplicitConversion()
+        {
+            var error = new Error("")
+                .CausedBy("First error message");
+
+            Result<string> result = error;
+
+            result.IsFailed.Should().Be(true);
+            result.Reasons.Should().HaveCount(1);
+            error.Reasons.First().Message.Should().Be("First error message");
+        }
+        
+        [Fact]
+        public void CreateErrorOfT_FromListOfErrorsImplicitConversion()
+        {
+            var errors = new List<Error>
+            {
+                new Error("First error message"),
+                new Error("Second error message"),
+            };
+
+            Result<string> result = errors;
+
+            result.IsFailed.Should().Be(true);
+            result.Reasons.Should().HaveCount(2);
+            result.Reasons[0].Message.Should().Be("First error message");
+            result.Reasons[1].Message.Should().Be("Second error message");
+        }
     }
 }

--- a/src/FluentResults/Results/Result.cs
+++ b/src/FluentResults/Results/Result.cs
@@ -471,6 +471,16 @@ namespace FluentResults
 
             return Result.Ok(value);
         }
+        
+        public static implicit operator Result<TValue>(Error error)
+        {
+            return Result.Fail(error);
+        }
+
+        public static implicit operator Result<TValue>(List<Error> errors)
+        {
+            return Result.Fail(errors);
+        }
 
         /// <summary>
         /// Deconstruct Result


### PR DESCRIPTION
My first PR for implicit conversion from Errors to fail result wasn't working for Result of T.

I was pretty sure the implicit conversion could be done twice. Error --> Result --> Result of T   but it doesn't.