### PR TITLE
Better return types for lists that aren't really mutable

### DIFF
--- a/src/FluentResults.Samples/WebController/ResultDtoExtensions.cs
+++ b/src/FluentResults.Samples/WebController/ResultDtoExtensions.cs
@@ -13,7 +13,7 @@ namespace FluentResults.Samples.WebController
             return new ResultDto(false, TransformErrors(result.Errors));
         }
 
-        private static IEnumerable<ErrorDto> TransformErrors(List<IError> errors)
+        private static IEnumerable<ErrorDto> TransformErrors(IEnumerable<IError> errors)
         {
             return errors.Select(TransformError);
         }

--- a/src/FluentResults/Factories/ResultHelper.cs
+++ b/src/FluentResults/Factories/ResultHelper.cs
@@ -27,7 +27,7 @@ namespace FluentResults
         }
 
         public static bool HasError<TError>(
-            List<IError> errors,
+            IEnumerable<IError> errors,
             Func<TError, bool> predicate,
             out IEnumerable<TError> result)
             where TError : IError
@@ -53,7 +53,7 @@ namespace FluentResults
         }
 
         public static bool HasException<TException>(
-            List<IError> errors,
+            IEnumerable<IError> errors,
             Func<TException, bool> predicate,
             out IEnumerable<IError> result)
             where TException : Exception
@@ -83,7 +83,7 @@ namespace FluentResults
         }
 
         public static bool HasSuccess<TSuccess>(
-            List<ISuccess> successes, 
+            IEnumerable<ISuccess> successes, 
             Func<TSuccess, bool> predicate,
             out IEnumerable<TSuccess> result) where TSuccess : ISuccess
         {

--- a/src/FluentResults/Results/Result.cs
+++ b/src/FluentResults/Results/Result.cs
@@ -497,7 +497,7 @@ namespace FluentResults
             isSuccess = IsSuccess;
             isFailed = IsFailed;
             value = IsSuccess ? Value : default;
-            errors = IsFailed ? Errors : default;
+            errors = IsFailed ? Errors.ToList() : default;
         }
 
         private void ThrowIfFailed()

--- a/src/FluentResults/Results/ResultBase.cs
+++ b/src/FluentResults/Results/ResultBase.cs
@@ -26,12 +26,12 @@ namespace FluentResults
         /// <summary>
         /// Get all errors
         /// </summary>
-        List<IError> Errors { get; }
+        IReadOnlyList<IError> Errors { get; }
 
         /// <summary>
         /// Get all successes
         /// </summary>
-        List<ISuccess> Successes { get; }
+        IReadOnlyList<ISuccess> Successes { get; }
     }
 
     public abstract class ResultBase : IResultBase
@@ -54,12 +54,12 @@ namespace FluentResults
         /// <summary>
         /// <inheritdoc/>
         /// </summary>
-        public List<IError> Errors => Reasons.OfType<IError>().ToList();
+        public IReadOnlyList<IError> Errors => Reasons.OfType<IError>().ToList().AsReadOnly();
 
         /// <summary>
         /// <inheritdoc/>
         /// </summary>
-        public List<ISuccess> Successes => Reasons.OfType<ISuccess>().ToList();
+        public IReadOnlyList<ISuccess> Successes => Reasons.OfType<ISuccess>().ToList().AsReadOnly();
 
         protected ResultBase()
         {
@@ -226,7 +226,7 @@ namespace FluentResults
         {
             isSuccess = IsSuccess;
             isFailed = IsFailed;
-            errors = IsFailed ? Errors : default;
+            errors = IsFailed ? Errors.ToList() : default;
         }
     }
 


### PR DESCRIPTION
`IResult` exposes mutable lists for the `Errors` and `Successes` properties, however, when implemented in `ResultsBase`, these Lists aren't really mutable in the sense that each time you access the property you are in fact getting a new list. This violates Principle of Least Surprise, for the simple fact that you can create a `ResultBase` derived instance, add to the `Errors` list and on subsequent access the list appears empty (in fact it's a different reference). Example:

 `  var result = new Result();`
    `result.Errors.Add(new Error("Something failed"));`
  `  result.Errors.Count == 0; // Evaluates to true;`

This PR updates some of the return types to better communicate the intent of the `IResult` contract.