### PR TITLE
Fixes HaveValue method when type is a class

### DIFF
--- a/src/FluentResults.Extensions.FluentAssertions.Test/ValueResultTests/HaveValueTests.cs
+++ b/src/FluentResults.Extensions.FluentAssertions.Test/ValueResultTests/HaveValueTests.cs
@@ -40,5 +40,41 @@ namespace FluentResults.Extensions.FluentAssertions.Test.ValueResultTests
                 .Throw<XunitException>()
                 .WithMessage("Value can not be asserted because result is failed because of 'Error 1'");
         }
+
+        [Fact]
+        public void Asserting_null_should_not_throw_exceptions_when_type_is_a_primitive()
+        {
+            var successResult = Result.Ok(null as int?);
+
+            Action action = () => successResult.Should().HaveValue(null);
+
+            action.Should().NotThrow();
+        }
+
+        [Fact]
+        public void Asserting_null_should_not_throw_exceptions_when_type_is_a_struct()
+        {
+            var successResult = Result.Ok(null as SomeStruct?);
+
+            Action action = () => successResult.Should().HaveValue(null);
+
+            action.Should().NotThrow();
+        }
+
+        [Fact]
+        public void Asserting_null_should_not_throw_exceptions_when_type_is_a_class()
+        {
+            var successResult = Result.Ok(null as SomeClass);
+
+            Action action = () => successResult.Should().HaveValue(null);
+
+            action.Should().NotThrow();
+        }
+
+        internal struct SomeStruct
+        { }
+
+        internal class SomeClass
+        { }
     }
 }

--- a/src/FluentResults.Extensions.FluentAssertions/Assertions/AssertionOperators.cs
+++ b/src/FluentResults.Extensions.FluentAssertions/Assertions/AssertionOperators.cs
@@ -98,7 +98,7 @@ namespace FluentResults.Extensions.FluentAssertions
                    .FailWith("Value can not be asserted because result is failed because of '{0}'", subject.Errors)
                    .Then
                    .Given(() => subject.Value)
-                   .ForCondition(actualValue => actualValue.Equals(expectedValue))
+                   .ForCondition(actualValue => (actualValue == null && expectedValue == null) || actualValue.Equals(expectedValue))
                    .FailWith("Expected value is '{0}', but is '{1}'", expectedValue, subject.Value);
 
             return new AndConstraint<TResultAssertion>(parentConstraint);


### PR DESCRIPTION
Fixes #172 

As `==` and `.Equals()` can bring some different results depending the code written and/or overrides, I added one extra null comparison step before the current checking.