### PR TITLE
Fixed equality comparer inside ReasonAssertions.HaveMetadata().

### DIFF
--- a/src/FluentResults.Extensions.FluentAssertions/Assertions/ReasonAssertions.cs
+++ b/src/FluentResults.Extensions.FluentAssertions/Assertions/ReasonAssertions.cs
@@ -22,7 +22,7 @@ namespace FluentResults.Extensions.FluentAssertions
                    .ForCondition(metadata =>
                                  {
                                      metadata.TryGetValue(metadataKey, out var actualMetadataValue);
-                                     return actualMetadataValue == metadataValue;
+                                     return Equals(actualMetadataValue, metadataValue);
                                  })
                    .FailWith($"Reason should contain '{metadataKey}' with '{metadataValue}', but not contain it");
 


### PR DESCRIPTION
Fix the HaveMetadata equality comparer; now it will compare metadata values using the Equals comparer, as it is usually used to compare by value rather than by reference.