### PR TITLE
Added README.md to nuget package to be presented on nuget.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-<img src="https://github.com/altmann/FluentResults/blob/master/resources/icons/FluentResults-Icon-64.png" alt="FluentResults"/>
-
+<img src="https://raw.githubusercontent.com/altmann/FluentResults/master/resources/icons/FluentResults-Icon-64.png" alt="FluentResults"/>
 # FluentResults
 
 [![Nuget downloads](https://img.shields.io/nuget/v/fluentresults.svg)](https://www.nuget.org/packages/FluentResults/)

--- a/src/FluentResults/FluentResults.csproj
+++ b/src/FluentResults/FluentResults.csproj
@@ -15,7 +15,8 @@
     <PackageProjectUrl>https://github.com/altmann/FluentResults</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/altmann/FluentResults/master/resources/icons/FluentResults-Icon-128.png</PackageIconUrl>
     <PackageIcon>FluentResults-Icon-128.png</PackageIcon>
-
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    
     <!--SourceLink-->
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
@@ -27,6 +28,10 @@
 
   <ItemGroup>
     <None Include="..\..\resources\icons\FluentResults-Icon-128.png" Pack="true" PackagePath="" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
After adding the README.md file to the package, the repository's README file can now be viewed at nuget.org.
Resolves #203 