### PR TITLE
Add Try with result return

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,21 @@ In some scenarios you want to execute an action. If this action throws an except
 var result = Result.Try(() => DoSomethingCritical());
 ```
 
+You can also return your own `Result` object
+
+```csharp
+var result = Result.Try(() => {
+    if(IsInvalid()) 
+    {
+        return Result.Fail("Some error");
+    }
+
+    int id = DoSomethingCritical();
+
+    return Result.Ok(id);
+});
+```
+
 In the above example the default catchHandler is used. The behavior of the default catchHandler can be overwritten via the global Result settings (see next example). You can control how the Error object looks.
 
 ```csharp

--- a/src/FluentResults.Test/ResultWithValueTests.cs
+++ b/src/FluentResults.Test/ResultWithValueTests.cs
@@ -294,7 +294,7 @@ namespace FluentResults.Test
                     .Should()
                     .BeEquivalentTo("First error message");
             }
-            
+
             [Fact]
             public async Task Bind_ToAnotherValueTypeWithFailedResult_ReturnFailedResultTask()
             {
@@ -309,7 +309,7 @@ namespace FluentResults.Test
                     .Should()
                     .BeEquivalentTo("First error message");
             }
-            
+
             [Fact]
             public async Task Bind_ToAnotherValueTypeWithFailedResult_ReturnFailedResultValueTask()
             {
@@ -324,7 +324,7 @@ namespace FluentResults.Test
                     .Should()
                     .BeEquivalentTo("First error message");
             }
-            
+
             [Fact]
             public void Bind_ToResultWithFailedResult_ReturnFailedResult()
             {
@@ -339,7 +339,7 @@ namespace FluentResults.Test
                     .Should()
                     .BeEquivalentTo("First error message");
             }
-            
+
             [Fact]
             public async Task Bind_ToResultWithFailedResult_ReturnFailedResultTask()
             {
@@ -354,7 +354,7 @@ namespace FluentResults.Test
                     .Should()
                     .BeEquivalentTo("First error message");
             }
-            
+
             [Fact]
             public async Task Bind_ToResultWithFailedResult_ReturnFailedResultValueTask()
             {
@@ -369,7 +369,7 @@ namespace FluentResults.Test
                     .Should()
                     .BeEquivalentTo("First error message");
             }
-            
+
             [Fact]
             public void Bind_ToAnotherValueTypeWithFailedResultAndFailedTransformation_ReturnFailedResult()
             {
@@ -384,7 +384,7 @@ namespace FluentResults.Test
                     .Should()
                     .BeEquivalentTo("Original error message");
             }
-            
+
             [Fact]
             public async Task Bind_ToAnotherValueTypeWithFailedResultAndFailedTransformation_ReturnFailedResultTask()
             {
@@ -399,7 +399,7 @@ namespace FluentResults.Test
                     .Should()
                     .BeEquivalentTo("Original error message");
             }
-            
+
             [Fact]
             public async Task Bind_ToAnotherValueTypeWithFailedResultAndFailedTransformation_ReturnFailedResultValueTask()
             {
@@ -414,7 +414,7 @@ namespace FluentResults.Test
                     .Should()
                     .BeEquivalentTo("Original error message");
             }
-            
+
             [Fact]
             public void Bind_ToResultWithFailedResultAndFailedTransformation_ReturnFailedResult()
             {
@@ -429,7 +429,7 @@ namespace FluentResults.Test
                     .Should()
                     .BeEquivalentTo("Original error message");
             }
-            
+
             [Fact]
             public async Task Bind_ToResultWithFailedResultAndFailedTransformation_ReturnFailedResultTask()
             {
@@ -444,7 +444,7 @@ namespace FluentResults.Test
                     .Should()
                     .BeEquivalentTo("Original error message");
             }
-            
+
             [Fact]
             public async Task Bind_ToResultWithFailedResultAndFailedTransformation_ReturnFailedResultValueTask()
             {
@@ -466,8 +466,8 @@ namespace FluentResults.Test
                 var valueResult = Result.Ok(1).WithSuccess("An int");
 
                 // Act
-                var result = valueResult.Bind(n => n == 1 
-                    ? "One".ToResult().WithSuccess("It is one") 
+                var result = valueResult.Bind(n => n == 1
+                    ? "One".ToResult().WithSuccess("It is one")
                     : Result.Fail<string>("Only one accepted"));
 
                 // Assert
@@ -479,15 +479,15 @@ namespace FluentResults.Test
                     .Should()
                     .BeEquivalentTo("An int", "It is one");
             }
-            
+
             [Fact]
             public async Task Bind_ToAnotherValueTypeWhichIsSuccessful_ReturnsSuccessResultTask()
             {
                 var valueResult = Result.Ok(1).WithSuccess("An int");
 
                 // Act
-                var result = await valueResult.Bind(n => Task.FromResult(n == 1 
-                    ? "One".ToResult().WithSuccess("It is one") 
+                var result = await valueResult.Bind(n => Task.FromResult(n == 1
+                    ? "One".ToResult().WithSuccess("It is one")
                     : Result.Fail<string>("Only one accepted")));
 
                 // Assert
@@ -499,15 +499,15 @@ namespace FluentResults.Test
                     .Should()
                     .BeEquivalentTo("An int", "It is one");
             }
-            
+
             [Fact]
             public async Task Bind_ToAnotherValueTypeWhichIsSuccessful_ReturnsSuccessResultValueTask()
             {
                 var valueResult = Result.Ok(1).WithSuccess("An int");
 
                 // Act
-                var result = await valueResult.Bind(n => new ValueTask<Result<string>>(n == 1 
-                    ? "One".ToResult().WithSuccess("It is one") 
+                var result = await valueResult.Bind(n => new ValueTask<Result<string>>(n == 1
+                    ? "One".ToResult().WithSuccess("It is one")
                     : Result.Fail<string>("Only one accepted")));
 
                 // Assert
@@ -519,7 +519,7 @@ namespace FluentResults.Test
                     .Should()
                     .BeEquivalentTo("An int", "It is one");
             }
-            
+
             [Fact]
             public void Bind_ToResultWhichIsSuccessful_ReturnsSuccessResult()
             {
@@ -534,7 +534,7 @@ namespace FluentResults.Test
                     .Should()
                     .BeEquivalentTo("First number", "It is one");
             }
-            
+
             [Fact]
             public async Task Bind_ToResultWhichIsSuccessful_ReturnsSuccessResultTask()
             {
@@ -549,7 +549,7 @@ namespace FluentResults.Test
                     .Should()
                     .BeEquivalentTo("First number", "It is one");
             }
-            
+
             [Fact]
             public async Task Bind_ToResultWhichIsSuccessful_ReturnsSuccessResultValueTask()
             {
@@ -564,7 +564,7 @@ namespace FluentResults.Test
                     .Should()
                     .BeEquivalentTo("First number", "It is one");
             }
-            
+
             [Fact]
             public void Bind_ToAnotherValueTypeWhichFailedTransformation_ReturnsFailedResult()
             {
@@ -580,7 +580,7 @@ namespace FluentResults.Test
                     .Should()
                     .BeEquivalentTo("Only one accepted");
             }
-            
+
             [Fact]
             public async Task Bind_ToAnotherValueTypeWhichFailedTransformation_ReturnsFailedResultTask()
             {
@@ -596,7 +596,7 @@ namespace FluentResults.Test
                     .Should()
                     .BeEquivalentTo("Only one accepted");
             }
-            
+
             [Fact]
             public async Task Bind_ToAnotherValueTypeWhichFailedTransformation_ReturnsFailedResultValueTask()
             {
@@ -612,7 +612,7 @@ namespace FluentResults.Test
                     .Should()
                     .BeEquivalentTo("Only one accepted");
             }
-            
+
             [Fact]
             public void Bind_ToResultWhichFailedTransformation_ReturnsFailedResult()
             {
@@ -628,7 +628,7 @@ namespace FluentResults.Test
                     .Should()
                     .BeEquivalentTo("Only one accepted");
             }
-            
+
             [Fact]
             public async Task Bind_ToResultWhichFailedTransformation_ReturnsFailedResultTask()
             {
@@ -644,7 +644,7 @@ namespace FluentResults.Test
                     .Should()
                     .BeEquivalentTo("Only one accepted");
             }
-            
+
             [Fact]
             public async Task Bind_ToResultWhichFailedTransformation_ReturnsFailedResultValueTask()
             {
@@ -787,6 +787,126 @@ namespace FluentResults.Test
         {
             var exception = new Exception("ex message");
             ValueTask<int> Action() => throw exception;
+
+            var result = await Result.Try(Action, _ => new Error("xy"));
+
+            result.IsSuccess.Should().BeFalse();
+            result.Errors.Should().HaveCount(1);
+
+            var error = result.Errors.First();
+            error.Message.Should().Be("xy");
+        }
+
+        [Fact]
+        public void Try_execute_failed_func_return_failed_result()
+        {
+            var error = new Error("xy");
+            Result<int> Action() => Result.Fail<int>(error);
+
+            var result = Result.Try(Action);
+
+            result.IsSuccess.Should().BeFalse();
+            result.Errors.Should().HaveCount(1);
+            result.Errors.First().Should().Be(error);
+        }
+
+        [Fact]
+        public async Task Try_execute_failed_func_async_return_failed_result()
+        {
+            var error = new Error("xy");
+            Task<Result<int>> Action() => Task.FromResult(Result.Fail<int>(error));
+
+            var result = await Result.Try(Action);
+
+            result.IsSuccess.Should().BeFalse();
+            result.Errors.Should().HaveCount(1);
+            result.Errors.First().Should().Be(error);
+        }
+
+        [Fact]
+        public async Task Try_execute_failed_valuetask_func_async_return_failed_result()
+        {
+            var error = new Error("xy");
+            ValueTask<Result<int>> Action() => new ValueTask<Result<int>>(Result.Fail<int>(error));
+
+            var result = await Result.Try(Action);
+
+            result.IsSuccess.Should().BeFalse();
+            result.Errors.Should().HaveCount(1);
+            result.Errors.First().Should().Be(error);
+        }
+
+        [Fact]
+        public void Try_execute_success_func_return_success_result()
+        {
+            Result<int> Action() => Result.Ok(5);
+
+            var result = Result.Try(Action);
+
+            result.IsSuccess.Should().BeTrue();
+            result.Value.Should().Be(5);
+            result.Errors.Should().BeEmpty();
+        }
+
+        [Fact]
+        public async Task Try_execute_success_func_async_return_success_result()
+        {
+            Task<Result<int>> Action() => Task.FromResult(Result.Ok(5));
+
+            var result = await Result.Try(Action);
+
+            result.IsSuccess.Should().BeTrue();
+            result.Value.Should().Be(5);
+            result.Errors.Should().BeEmpty();
+        }
+
+        [Fact]
+        public async Task Try_execute_success_valuetask_func_async_return_success_result()
+        {
+            ValueTask<Result<int>> Action() => new ValueTask<Result<int>>(Result.Ok(5));
+
+            var result = await Result.Try(Action);
+
+            result.IsSuccess.Should().BeTrue();
+            result.Value.Should().Be(5);
+            result.Errors.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void Try_execute_withresult_failed_task_action_with_custom_catchHandler_return_failed_result()
+        {
+            var exception = new Exception("ex message");
+            Result<int> Action() => throw exception;
+
+            var result = Result.Try(Action, _ => new Error("xy"));
+
+            result.IsSuccess.Should().BeFalse();
+            result.Errors.Should().HaveCount(1);
+
+            var error = result.Errors.First();
+            error.Message.Should().Be("xy");
+        }
+
+        [Fact]
+        public async Task Try_execute_withresult_failed_task_async_action_with_custom_catchHandler_return_failed_result()
+        {
+            var exception = new Exception("ex message");
+            Task<Result<int>> Action() => throw exception;
+
+            var result = await Result.Try(Action, _ => new Error("xy"));
+
+            result.IsSuccess.Should().BeFalse();
+            result.Errors.Should().HaveCount(1);
+
+            var error = result.Errors.First();
+            error.Message.Should().Be("xy");
+        }
+
+        [Fact]
+        public async Task Try_execute_withresult_failed_valuetask_async_action_with_custom_catchHandler_return_failed_result()
+        {
+            var exception = new Exception("ex message");
+            ValueTask<Result<int>> Action() => throw exception;
 
             var result = await Result.Try(Action, _ => new Error("xy"));
 
@@ -954,7 +1074,7 @@ namespace FluentResults.Test
         {
             var result = new Result<dynamic>();
             var converted = Convert.ChangeType(source, dest);
-            var x =  result.WithValue(converted);
+            var x = result.WithValue(converted);
             return x;
         }
     }

--- a/src/FluentResults.Test/ResultWithoutValueTests.cs
+++ b/src/FluentResults.Test/ResultWithoutValueTests.cs
@@ -1,6 +1,6 @@
+using FluentAssertions;
 using System;
 using System.Collections.Generic;
-using FluentAssertions;
 using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
@@ -487,6 +487,123 @@ namespace FluentResults.Test
         }
 
         [Fact]
+        public void Try_execute_failed_func_return_failed_result()
+        {
+            var error = new Error("xy");
+            Result Action() => Result.Fail(error);
+
+            var result = Result.Try(Action);
+
+            result.IsSuccess.Should().BeFalse();
+            result.Errors.Should().HaveCount(1);
+            result.Errors.First().Should().Be(error);
+        }
+
+        [Fact]
+        public async Task Try_execute_failed_func_async_return_failed_result()
+        {
+            var error = new Error("xy");
+            Task<Result> Action() => Task.FromResult(Result.Fail(error));
+
+            var result = await Result.Try(Action);
+
+            result.IsSuccess.Should().BeFalse();
+            result.Errors.Should().HaveCount(1);
+            result.Errors.First().Should().Be(error);
+        }
+
+        [Fact]
+        public async Task Try_execute_failed_valuetask_func_async_return_failed_result()
+        {
+            var error = new Error("xy");
+            ValueTask<Result> Action() => new ValueTask<Result>(Result.Fail(error));
+
+            var result = await Result.Try(Action);
+
+            result.IsSuccess.Should().BeFalse();
+            result.Errors.Should().HaveCount(1);
+            result.Errors.First().Should().Be(error);
+        }
+
+        [Fact]
+        public void Try_execute_success_func_return_success_result()
+        {
+            Result Action() => Result.Ok();
+
+            var result = Result.Try(Action);
+
+            result.IsSuccess.Should().BeTrue();
+            result.Errors.Should().BeEmpty();
+        }
+
+        [Fact]
+        public async Task Try_execute_success_func_async_return_success_result()
+        {
+            Task<Result> Action() => Task.FromResult(Result.Ok());
+
+            var result = await Result.Try(Action);
+
+            result.IsSuccess.Should().BeTrue();
+            result.Errors.Should().BeEmpty();
+        }
+
+        [Fact]
+        public async Task Try_execute_success_valuetask_func_async_return_success_result()
+        {
+            ValueTask<Result> Action() => new ValueTask<Result>(Result.Ok());
+
+            var result = await Result.Try(Action);
+
+            result.IsSuccess.Should().BeTrue();
+            result.Errors.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void Try_execute_withresult_failed_task_action_with_custom_catchHandler_return_failed_result()
+        {
+            var exception = new Exception("ex message");
+            Result Action() => throw exception;
+
+            var result = Result.Try(Action, _ => new Error("xy"));
+
+            result.IsSuccess.Should().BeFalse();
+            result.Errors.Should().HaveCount(1);
+
+            var error = result.Errors.First();
+            error.Message.Should().Be("xy");
+        }
+
+        [Fact]
+        public async Task Try_execute_withresult_failed_task_async_action_with_custom_catchHandler_return_failed_result()
+        {
+            var exception = new Exception("ex message");
+            Task<Result> Action() => throw exception;
+
+            var result = await Result.Try(Action, _ => new Error("xy"));
+
+            result.IsSuccess.Should().BeFalse();
+            result.Errors.Should().HaveCount(1);
+
+            var error = result.Errors.First();
+            error.Message.Should().Be("xy");
+        }
+
+        [Fact]
+        public async Task Try_execute_withresult_failed_valuetask_async_action_with_custom_catchHandler_return_failed_result()
+        {
+            var exception = new Exception("ex message");
+            ValueTask<Result> Action() => throw exception;
+
+            var result = await Result.Try(Action, _ => new Error("xy"));
+
+            result.IsSuccess.Should().BeFalse();
+            result.Errors.Should().HaveCount(1);
+
+            var error = result.Errors.First();
+            error.Message.Should().Be("xy");
+        }
+
+        [Fact]
         public void Can_deconstruct_non_generic_Ok_to_isSuccess_and_isFailed()
         {
             var (isSuccess, isFailed) = Result.Ok();
@@ -543,7 +660,7 @@ namespace FluentResults.Test
                     .Should()
                     .BeEquivalentTo("First error message");
             }
-            
+
             [Fact]
             public async Task Bind_ToAnotherValueTypeWithFailedResult_ReturnFailedResultTask()
             {
@@ -558,7 +675,7 @@ namespace FluentResults.Test
                     .Should()
                     .BeEquivalentTo("First error message");
             }
-            
+
             [Fact]
             public async Task Bind_ToAnotherValueTypeWithFailedResult_ReturnFailedResultValueTask()
             {
@@ -573,7 +690,7 @@ namespace FluentResults.Test
                     .Should()
                     .BeEquivalentTo("First error message");
             }
-            
+
             [Fact]
             public void Bind_ToResultWithFailedResult_ReturnFailedResult()
             {
@@ -588,7 +705,7 @@ namespace FluentResults.Test
                     .Should()
                     .BeEquivalentTo("First error message");
             }
-            
+
             [Fact]
             public async Task Bind_ToResultWithFailedResult_ReturnFailedResultTask()
             {
@@ -603,7 +720,7 @@ namespace FluentResults.Test
                     .Should()
                     .BeEquivalentTo("First error message");
             }
-            
+
             [Fact]
             public async Task Bind_ToResultWithFailedResult_ReturnFailedResultValueTask()
             {
@@ -618,7 +735,7 @@ namespace FluentResults.Test
                     .Should()
                     .BeEquivalentTo("First error message");
             }
-            
+
             [Fact]
             public void Bind_ToAnotherValueTypeWithFailedResultAndFailedTransformation_ReturnFailedResult()
             {
@@ -633,7 +750,7 @@ namespace FluentResults.Test
                     .Should()
                     .BeEquivalentTo("Original error message");
             }
-            
+
             [Fact]
             public async Task Bind_ToAnotherValueTypeWithFailedResultAndFailedTransformation_ReturnFailedResultTask()
             {
@@ -648,7 +765,7 @@ namespace FluentResults.Test
                     .Should()
                     .BeEquivalentTo("Original error message");
             }
-            
+
             [Fact]
             public async Task Bind_ToAnotherValueTypeWithFailedResultAndFailedTransformation_ReturnFailedResultValueTask()
             {
@@ -663,7 +780,7 @@ namespace FluentResults.Test
                     .Should()
                     .BeEquivalentTo("Original error message");
             }
-            
+
             [Fact]
             public void Bind_ToResultWithFailedResultAndFailedTransformation_ReturnFailedResult()
             {
@@ -678,7 +795,7 @@ namespace FluentResults.Test
                     .Should()
                     .BeEquivalentTo("Original error message");
             }
-            
+
             [Fact]
             public async Task Bind_ToResultWithFailedResultAndFailedTransformation_ReturnFailedResultTask()
             {
@@ -693,7 +810,7 @@ namespace FluentResults.Test
                     .Should()
                     .BeEquivalentTo("Original error message");
             }
-            
+
             [Fact]
             public async Task Bind_ToResultWithFailedResultAndFailedTransformation_ReturnFailedResultValueTask()
             {
@@ -726,7 +843,7 @@ namespace FluentResults.Test
                     .Should()
                     .BeEquivalentTo("An int", "It is one");
             }
-            
+
             [Fact]
             public async Task Bind_ToAnotherValueTypeWhichIsSuccessful_ReturnsSuccessResultTask()
             {
@@ -744,7 +861,7 @@ namespace FluentResults.Test
                     .Should()
                     .BeEquivalentTo("An int", "It is one");
             }
-            
+
             [Fact]
             public async Task Bind_ToAnotherValueTypeWhichIsSuccessful_ReturnsSuccessResultValueTask()
             {
@@ -762,7 +879,7 @@ namespace FluentResults.Test
                     .Should()
                     .BeEquivalentTo("An int", "It is one");
             }
-            
+
             [Fact]
             public void Bind_ToResultWhichIsSuccessful_ReturnsSuccessResult()
             {
@@ -777,7 +894,7 @@ namespace FluentResults.Test
                     .Should()
                     .BeEquivalentTo("First number", "It is one");
             }
-            
+
             [Fact]
             public async Task Bind_ToResultWhichIsSuccessful_ReturnsSuccessResultTask()
             {
@@ -792,7 +909,7 @@ namespace FluentResults.Test
                     .Should()
                     .BeEquivalentTo("First number", "It is one");
             }
-            
+
             [Fact]
             public async Task Bind_ToResultWhichIsSuccessful_ReturnsSuccessResultValueTask()
             {
@@ -807,7 +924,7 @@ namespace FluentResults.Test
                     .Should()
                     .BeEquivalentTo("First number", "It is one");
             }
-            
+
             [Fact]
             public void Bind_ToAnotherValueTypeWhichFailedTransformation_ReturnsFailedResult()
             {
@@ -823,7 +940,7 @@ namespace FluentResults.Test
                     .Should()
                     .BeEquivalentTo("Only one accepted");
             }
-            
+
             [Fact]
             public async Task Bind_ToAnotherValueTypeWhichFailedTransformation_ReturnsFailedResultTask()
             {
@@ -839,7 +956,7 @@ namespace FluentResults.Test
                     .Should()
                     .BeEquivalentTo("Only one accepted");
             }
-            
+
             [Fact]
             public async Task Bind_ToAnotherValueTypeWhichFailedTransformation_ReturnsFailedResultValueTask()
             {
@@ -855,7 +972,7 @@ namespace FluentResults.Test
                     .Should()
                     .BeEquivalentTo("Only one accepted");
             }
-            
+
             [Fact]
             public void Bind_ToResultWhichFailedTransformation_ReturnsFailedResult()
             {
@@ -871,7 +988,7 @@ namespace FluentResults.Test
                     .Should()
                     .BeEquivalentTo("Only one accepted");
             }
-            
+
             [Fact]
             public async Task Bind_ToResultWhichFailedTransformation_ReturnsFailedResultTask()
             {
@@ -887,7 +1004,7 @@ namespace FluentResults.Test
                     .Should()
                     .BeEquivalentTo("Only one accepted");
             }
-            
+
             [Fact]
             public async Task Bind_ToResultWhichFailedTransformation_ReturnsFailedResultValueTask()
             {

--- a/src/FluentResults/Factories/Results.cs
+++ b/src/FluentResults/Factories/Results.cs
@@ -33,7 +33,7 @@ namespace FluentResults
         {
             return new Result();
         }
-        
+
         /// <summary>
         /// Creates a failed result with the given error
         /// </summary>
@@ -53,7 +53,7 @@ namespace FluentResults
             result.WithError(Settings.ErrorFactory(errorMessage));
             return result;
         }
-        
+
         /// <summary>
         /// Creates a failed result with the given error messages. Internally a list of error objects from the error factory is created
         /// </summary>
@@ -61,7 +61,7 @@ namespace FluentResults
         {
             if (errorMessages == null)
                 throw new ArgumentNullException(nameof(errorMessages), "The list of error messages cannot be null");
-            
+
             var result = new Result();
             result.WithErrors(errorMessages.Select(Settings.ErrorFactory));
             return result;
@@ -109,7 +109,7 @@ namespace FluentResults
             result.WithError(Settings.ErrorFactory(errorMessage));
             return result;
         }
-        
+
         /// <summary>
         /// Creates a failed result with the given error messages. Internally a list of error objects from the error factory is created. 
         /// </summary>
@@ -117,7 +117,7 @@ namespace FluentResults
         {
             if (errorMessages == null)
                 throw new ArgumentNullException(nameof(errorMessages), "The list of error messages cannot be null");
-            
+
             var result = new Result<TValue>();
             result.WithErrors(errorMessages.Select(Settings.ErrorFactory));
             return result;
@@ -332,5 +332,110 @@ namespace FluentResults
                 return Fail(catchHandler(e));
             }
         }
+
+        /// <summary>
+        /// Executes the action. If an exception is thrown within the action then this exception is transformed via the catchHandler to an Error object
+        /// </summary>
+        public static Result Try(Func<Result> action, Func<Exception, IError> catchHandler = null)
+        {
+            catchHandler = catchHandler ?? Settings.DefaultTryCatchHandler;
+
+            try
+            {
+                return action();
+            }
+            catch (Exception e)
+            {
+                return Fail(catchHandler(e));
+            }
+
+        }
+
+        /// <summary>
+        /// Executes the action. If an exception is thrown within the action then this exception is transformed via the catchHandler to an Error object
+        /// </summary>
+        public static async Task<Result> Try(Func<Task<Result>> action, Func<Exception, IError> catchHandler = null)
+        {
+            catchHandler = catchHandler ?? Settings.DefaultTryCatchHandler;
+
+            try
+            {
+                return await action();
+            }
+            catch (Exception e)
+            {
+                return Fail(catchHandler(e));
+            }
+        }
+
+        /// <summary>
+        /// Executes the action. If an exception is thrown within the action then this exception is transformed via the catchHandler to an Error object
+        /// </summary>
+        public static async ValueTask<Result> Try(Func<ValueTask<Result>> action, Func<Exception, IError> catchHandler = null)
+        {
+            catchHandler = catchHandler ?? Settings.DefaultTryCatchHandler;
+
+            try
+            {
+                return await action();
+            }
+            catch (Exception e)
+            {
+                return Fail(catchHandler(e));
+            }
+        }
+
+        /// <summary>
+        /// Executes the action. If an exception is thrown within the action then this exception is transformed via the catchHandler to an Error object
+        /// </summary>
+        public static Result<T> Try<T>(Func<Result<T>> action, Func<Exception, IError> catchHandler = null)
+        {
+            catchHandler = catchHandler ?? Settings.DefaultTryCatchHandler;
+
+            try
+            {
+                return action();
+            }
+            catch (Exception e)
+            {
+                return Fail(catchHandler(e));
+            }
+
+        }
+
+        /// <summary>
+        /// Executes the action. If an exception is thrown within the action then this exception is transformed via the catchHandler to an Error object
+        /// </summary>
+        public static async Task<Result<T>> Try<T>(Func<Task<Result<T>>> action, Func<Exception, IError> catchHandler = null)
+        {
+            catchHandler = catchHandler ?? Settings.DefaultTryCatchHandler;
+
+            try
+            {
+                return await action();
+            }
+            catch (Exception e)
+            {
+                return Fail(catchHandler(e));
+            }
+        }
+
+        /// <summary>
+        /// Executes the action. If an exception is thrown within the action then this exception is transformed via the catchHandler to an Error object
+        /// </summary>
+        public static async ValueTask<Result<T>> Try<T>(Func<ValueTask<Result<T>>> action, Func<Exception, IError> catchHandler = null)
+        {
+            catchHandler = catchHandler ?? Settings.DefaultTryCatchHandler;
+
+            try
+            {
+                return await action();
+            }
+            catch (Exception e)
+            {
+                return Fail(catchHandler(e));
+            }
+        }
+
     }
 }


### PR DESCRIPTION
Adds new methods of Try that allow you to return a new result object

Fixes #166 

Prior to this, you would always get a `Result.Ok` as long as your action did not throw an exception.  This will allow you to further control the flow of your application