### PR TITLE
Add FailIf methods accepting a collection of errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,10 +163,23 @@ Very often you have to create a fail or success result depending on a condition.
 var result = string.IsNullOrEmpty(firstName) ? Result.Fail("First Name is empty") : Result.Ok();
 ```
 
-With the methods ```FailIf()``` and ```OkIf()``` you can also write in a more readable way:
+With the methods ```FailIf()``` and ```OkIf()``` you can also write in a more readable way.  You can also supply a collection of errors:
 
 ```csharp
 var result = Result.FailIf(string.IsNullOrEmpty(firstName), "First Name is empty");
+
+bool isValid = false; // Some check
+var errors = new List<Error>{ new Error("Error 1"), new Error("Error 2") };
+
+var result2 = Result.FailIf(isValid, errors);
+```
+
+If your success check is based on whether or not there are errors, you can use `FailIfNotEmpty()`
+
+```csharp
+var errors = PerformSomeValidation();
+
+var result = Result.FailIfNotEmpty(errors);
 ```
 
 If an error instance should be lazily initialized, overloads accepting ```Func<string>``` or ```Func<IError>``` can be used to that effect:
@@ -179,6 +192,12 @@ var result = Result.FailIf(
     () => new Error($"Item {list.First(IsDivisibleByTen)} should not be on the list"));
 
 bool IsDivisibleByTen(int i) => i % 10 == 0;
+
+var errors = PerformSomeValidation();
+
+var result = Result.FailIfNotEmpty(
+    errors,
+    (err) => new Error("Custom error message based on err"));
 
 // rest of the code
 ```

--- a/src/FluentResults.Test/ResultWithoutValueTests.cs
+++ b/src/FluentResults.Test/ResultWithoutValueTests.cs
@@ -272,6 +272,64 @@ namespace FluentResults.Test
         }
 
         [Fact]
+        public void FailIf_WithErrors_IsFailure()
+        {
+            // Arrange
+            string errorMessage = "Sample Error";
+            var errors = new List<IError> { new Error(errorMessage) };
+
+            // Act
+            var result = Result.FailIf(true, errors);
+
+            // Assert
+            result.IsFailed.Should().BeTrue();
+            result.Errors.Single().Message.Should().Be(errorMessage);
+        }
+
+        [Fact]
+        public void FailIf_WithNoErrors_IsSuccess()
+        {
+            // Arrange
+            var errors = new List<IError>();
+
+            // Act
+            var result = Result.FailIf(false, errors);
+
+            // Assert
+            Assert.True(result.IsSuccess);
+            Assert.Empty(result.Errors);
+        }
+
+        [Fact]
+        public void FailIfNotEmpty_WithErrors_IsFailure()
+        {
+            // Arrange
+            string errorMessage = "Sample Error";
+            var errors = new List<IError> { new Error(errorMessage) };
+
+            // Act
+            var result = Result.FailIfNotEmpty(errors);
+
+            // Assert
+            result.IsFailed.Should().BeTrue();
+            result.Errors.Single().Message.Should().Be(errorMessage);
+        }
+
+        [Fact]
+        public void FailIfNotEmpty_WithNoErrors_IsSuccess()
+        {
+            // Arrange
+            var errors = new List<IError>();
+
+            // Act
+            var result = Result.FailIfNotEmpty(errors);
+
+            // Assert
+            result.IsSuccess.Should().BeTrue();
+            result.Errors.Should().BeEmpty();
+        }
+
+        [Fact]
         public void OkIf_SuccessConditionIsTrueAndWithStringErrorMessage_CreateFailedResult()
         {
             var result = Result.OkIf(true, "Error message");

--- a/src/FluentResults/Factories/Results.cs
+++ b/src/FluentResults/Factories/Results.cs
@@ -229,6 +229,27 @@ namespace FluentResults
         }
 
         /// <summary>
+        /// Create a success/failed result depending on the parameter isFailure containing the specified errors
+        /// </summary>
+        public static Result FailIf(bool isFailure, IEnumerable<IError> errors)
+            => isFailure ? Fail(errors) : Ok();
+
+        /// <summary>
+        /// Create a success/failed result if any error objects exist
+        /// </summary>
+        public static Result FailIfNotEmpty(IEnumerable<IError> errors)
+            => errors.Any() ? Fail(errors) : Ok();
+
+        /// <summary>
+        /// Create a success/failed result depending if any error objects exist
+        /// </summary>
+        /// <remarks>
+        /// Error is lazily evaluated.
+        /// </remarks>
+        public static Result FailIfNotEmpty<T>(IEnumerable<T> errors, Func<T, IError> func)
+            => errors.Any() ? Fail(errors.Select(error => func(error))) : Ok();
+
+        /// <summary>
         /// Executes the action. If an exception is thrown within the action then this exception is transformed via the catchHandler to an Error object
         /// </summary>
         public static Result Try(Action action, Func<Exception, IError> catchHandler = null)


### PR DESCRIPTION
Adds methods to `FailIf` that will accept a collection of `Error` objects.

Closes #189 