### PR TITLE
182 Add enumerable support for Merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,17 @@ var results = new List<Result> { result1, result2, result3 };
 var mergedResult = results.Merge();
 ```
 
+You can also merge results containing a collection of elements into a flattened collection with `MergeFlat()`.  The value type and Enumerable type must be specified as generic parameters
+
+```csharp
+var result1 = Result.Ok(new string[] { "A", "B" });
+var result2 = Result.Ok(new string[] { "C", "D" });
+var result3 = Result.Ok(new string[] { "E", "F" });
+
+// Will contain ["A", "B", "C", "D", "E", "F"]
+var mergedResult = Result.MergeFlat<string, string[]>(result1, result2, result3);
+```
+
 ### Converting and Transformation
 
 A result object can be converted to another result object with methods `ToResult()` and `ToResult<TValue>()`.

--- a/src/FluentResults.Test/MergeTests.cs
+++ b/src/FluentResults.Test/MergeTests.cs
@@ -1,5 +1,6 @@
-﻿using System.Collections.Generic;
-using FluentAssertions;
+﻿using FluentAssertions;
+using System.Collections.Generic;
+using System.Linq;
 using Xunit;
 
 namespace FluentResults.Test
@@ -52,6 +53,57 @@ namespace FluentResults.Test
             mergedResult.Value.Should().BeEquivalentTo(new[]
             {
                 1, 2
+            });
+        }
+
+        [Fact]
+        public void MergeFlat_WithSuccessResultWithListValue_ShouldMergeResults()
+        {
+            var result1 = Result.Ok(new List<string> { "A", "B" });
+            var result2 = Result.Ok(new List<string> { "C", "D" });
+            var result3 = Result.Ok(new List<string> { "E", "F" });
+
+            var mergedResult = Result.MergeFlat<string, List<string>>(result1, result2, result3);
+
+            mergedResult.IsSuccess.Should().BeTrue();
+            mergedResult.Value.Should().HaveCount(6);
+            mergedResult.Value.Should().BeEquivalentTo(new[]
+            {
+                "A", "B", "C", "D", "E", "F"
+            });
+        }
+
+        [Fact]
+        public void MergeFlat_WithSuccessResultWithArrayValue_ShouldMergeResults()
+        {
+            var result1 = Result.Ok(new string[] { "A", "B" });
+            var result2 = Result.Ok(new string[] { "C", "D" });
+            var result3 = Result.Ok(new string[] { "E", "F" });
+
+            var mergedResult = Result.MergeFlat<string, string[]>(result1, result2, result3);
+
+            mergedResult.IsSuccess.Should().BeTrue();
+            mergedResult.Value.Should().HaveCount(6);
+            mergedResult.Value.Should().BeEquivalentTo(new[]
+            {
+                "A", "B", "C", "D", "E", "F"
+            });
+        }
+
+        [Fact]
+        public void MergeFlat_WithSuccessResultWithEnumerableValue_ShouldMergeResults()
+        {
+            Result<IEnumerable<string>> result1 = Result.Ok(new string[] { "A", "B" }.Select(a => a));
+            Result<IEnumerable<string>> result2 = Result.Ok(new string[] { "C", "D" }.Select(a => a));
+            Result<IEnumerable<string>> result3 = Result.Ok(new string[] { "E", "F" }.Select(a => a));
+
+            var mergedResult = Result.MergeFlat<string, IEnumerable<string>>(result1, result2, result3);
+
+            mergedResult.IsSuccess.Should().BeTrue();
+            mergedResult.Value.Should().HaveCount(6);
+            mergedResult.Value.Should().BeEquivalentTo(new[]
+            {
+                "A", "B", "C", "D", "E", "F"
             });
         }
     }

--- a/src/FluentResults/Factories/Results.cs
+++ b/src/FluentResults/Factories/Results.cs
@@ -153,6 +153,14 @@ namespace FluentResults
         }
 
         /// <summary>
+        /// Merge multiple result objects to one result object together. Return one result with a flattened list of merged values.
+        /// </summary>
+        public static Result<IEnumerable<TValue>> MergeFlat<TValue, TArray>(params Result<TArray>[] results) where TArray : IEnumerable<TValue>
+        {
+            return ResultHelper.MergeWithValue<TValue, TArray>(results);
+        }
+
+        /// <summary>
         /// Create a success/failed result depending on the parameter isSuccess
         /// </summary>
         public static Result OkIf(bool isSuccess, IError error)


### PR DESCRIPTION
Adds a `MergeFlat` method that will take in collections of TValue in your result set and return them as a single flattened `IEnumerable<TValue>`

Unfortunately, due to how C# infers type parameters for encapsulating types, you will need to specify the `TValue` and `TArray` types where `TArray : IEnumerable<TValue>`

```csharp
var result1 = Result.Ok(new string[] { "A", "B" });
var result2 = Result.Ok(new string[] { "C", "D" });
var result3 = Result.Ok(new string[] { "E", "F" });

// Will contain ["A", "B", "C", "D", "E", "F"]
var mergedResult = Result.MergeFlat<string, string[]>(result1, result2, result3);
```

Closes #182