### PR TITLE
ResultOrErrors deconstruct

### DIFF
--- a/README.md
+++ b/README.md
@@ -509,12 +509,18 @@ var outcome = result switch
 };
 ```
 
-### Deconstruct Operators
+### Golang-style Deconstruct Operators
 
 ```csharp
-var (isSuccess, isFailed, value, errors) = Result.Fail<bool>("Failure 1");
+// For Result<TValue> you get TValue and Errors
+var (result, errors) = Result.Ok(1);
+var (result, errors) = Result.Ok<int>(1);
+// beware that on error you will get "result==0" (since TValue is a non-nullable int), so you probably want to check errors first!
+var (result, errors) = Result.Fail<int>("fail");
 
-var (isSuccess, isFailed, errors) = Result.Fail("Failure 1");
+// For Result (without underlying value) you get bool isSuccess and Errors
+var (isSuccess, errors) = Result.Fail("Failure 1");
+var (isSuccess, errors) = Result.Ok();
 ```
 
 ### Logging

--- a/src/FluentResults.Test/ResultWithValueTests.cs
+++ b/src/FluentResults.Test/ResultWithValueTests.cs
@@ -998,21 +998,21 @@ namespace FluentResults.Test
         }
 
         [Fact]
-        public void Can_deconstruct_generic_Ok_to_isSuccess_and_isFailed()
+        public void Can_deconstruct_generic_Ok_to_isSuccess_and_errors()
         {
-            var (isSuccess, isFailed) = Result.Ok(true);
+            var (isSuccess, errors) = Result.Ok(true);
 
             isSuccess.Should().Be(true);
-            isFailed.Should().Be(false);
+            errors.Should().BeNull();
         }
 
         [Fact]
-        public void Can_deconstruct_generic_Fail_to_isSuccess_and_isFailed()
+        public void Can_deconstruct_generic_Fail_to_isSuccess_and_errors()
         {
-            var (isSuccess, isFailed) = Result.Fail<bool>("fail");
+            var (isSuccess, errors) = Result.Fail<bool>("fail");
 
             isSuccess.Should().Be(false);
-            isFailed.Should().Be(true);
+            errors.Should().NotBeNullOrEmpty();
         }
 
         [Fact]
@@ -1034,6 +1034,29 @@ namespace FluentResults.Test
             isFailed.Should().Be(true);
             value.Should().Be(default);
         }
+
+        [Fact]
+        public void Can_deconstruct_generic_Ok_to_value_with_errors()
+        {
+            var (value, errors) = Result.Ok(100);
+
+            value.Should().Be(100);
+            errors.Should().BeNull();
+        }
+
+        [Fact]
+        public void Can_deconstruct_generic_Fail_to_value_with_errors()
+        {
+            var error = new Error("fail");
+
+            var (value, errors) = Result.Fail<int>(error);
+
+            value.Should().Be(default);
+
+            errors.Count.Should().Be(1);
+            errors.FirstOrDefault().Should().Be(error);
+        }
+
 
         [Fact]
         public void Can_deconstruct_generic_Ok_to_isSuccess_and_isFailed_and_value_with_errors()

--- a/src/FluentResults/Results/Result.cs
+++ b/src/FluentResults/Results/Result.cs
@@ -196,7 +196,31 @@ namespace FluentResults
 
             return result;
         }
-        
+
+        /// <summary>
+        /// Deconstruct Result 
+        /// </summary>
+        /// <param name="isSuccess"></param>
+        /// <param name="isFailed"></param>
+        public void Deconstruct(out bool isSuccess, out bool isFailed)
+        {
+            isSuccess = IsSuccess;
+            isFailed = IsFailed;
+        }
+
+        /// <summary>
+        /// Deconstruct Result
+        /// </summary>
+        /// <param name="isSuccess"></param>
+        /// <param name="isFailed"></param>
+        /// <param name="errors"></param>
+        public void Deconstruct(out bool isSuccess, out bool isFailed, out List<IError> errors)
+        {
+            isSuccess = IsSuccess;
+            isFailed = IsFailed;
+            errors = IsFailed ? Errors : default;
+        }
+
         /// <summary>
         /// Implict conversion from <see cref="Error"/> to a <see cref="Result"/>
         /// </summary>
@@ -533,6 +557,17 @@ namespace FluentResults
         public static implicit operator Result<TValue>(List<Error> errors)
         {
             return Result.Fail(errors);
+        }
+
+        /// <summary>
+        /// Deconstruct Result
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="errors"></param>
+        public void Deconstruct(out TValue value, out List<IError> errors)
+        {
+            value = IsSuccess ? Value : default;
+            errors = IsFailed ? Errors : default;
         }
 
         /// <summary>

--- a/src/FluentResults/Results/ResultBase.cs
+++ b/src/FluentResults/Results/ResultBase.cs
@@ -213,30 +213,6 @@ namespace FluentResults
         {
             return ResultHelper.HasSuccess(Successes, predicate, out _);
         }
-
-        /// <summary>
-        /// Deconstruct Result 
-        /// </summary>
-        /// <param name="isSuccess"></param>
-        /// <param name="isFailed"></param>
-        public void Deconstruct(out bool isSuccess, out bool isFailed)
-        {
-            isSuccess = IsSuccess;
-            isFailed = IsFailed;
-        }
-
-        /// <summary>
-        /// Deconstruct Result
-        /// </summary>
-        /// <param name="isSuccess"></param>
-        /// <param name="isFailed"></param>
-        /// <param name="errors"></param>
-        public void Deconstruct(out bool isSuccess, out bool isFailed, out List<IError> errors)
-        {
-            isSuccess = IsSuccess;
-            isFailed = IsFailed;
-            errors = IsFailed ? Errors : default;
-        }
     }
 
     /// <summary>


### PR DESCRIPTION
Currently all deconstructors return a pair `bool isSuccess`/`bool isFailed`, which is slightly redundant (IMO only one would be enough, and if we are just interested in a single bool result we can just get the prop instead of using a desconstructor).

It becomes even more redundant in `Result<TValue>` since in that case we're also (we should be!) returning `TValue value` and possibly `List<IError> errors` - success/failure can just be infered from those values (if they are null) instead of having 4 different methods for testing the same thing.

Previously I've been just discarding the redundant variables: `var (_, _, result, errors) = MyServiceCall()`,  
but I thought that this cleaner/concise syntax could benefit everyone - so the 2-tuple deconstruct would just return us `TValue value` and `List<IError> errors`. (This concise style is used in golang and becoming popular elsewhere):  
`var (result, errors) = MyServiceCall()`.

**This PR adds to Result<TValue> that new golang-style deconstruct**: `Deconstruct(out TValue value, out List<IError> errors)`.  

ResultBase still has `Deconstruct(out bool isSuccess, out bool isFailed)`, so non-generic Results (without TValue) can still use that isSuccess/isFailed deconstruction (which IMO is redundant and provide little value).

**Breaking change**: if someone uses `Result<TValue>` and do the 2-tuple deconstruction (which is unlikely since it would ignore the possible return value and also the error list) then this deconstruction will break (will get different types and most likely will break compilation). 

The `<bool,bool>` deconstructor (which I think should be removed) was moved down from `ResultBase` to `Result`. So that 2-tuple deconstruct is still available when there's no underlying `TValue` (people using `Result<TValue>` should never be using that construct in the first place since it ignores the important TValue).