### PR TITLE
feat: Add OrFailIf extension method

### DIFF
--- a/src/FluentResults.Test/OrFailIfTests.cs
+++ b/src/FluentResults.Test/OrFailIfTests.cs
@@ -1,0 +1,43 @@
+using System.Linq;
+using FluentAssertions;
+using FluentResults.Extensions;
+using Xunit;
+
+namespace FluentResults.Test
+{
+    public class OrFailIfTests
+    {
+        [Fact]
+        public void Does_not_evaluate_if_the_previous_statement_has_failed()
+        {
+            var result = Result.FailIf(true, "Error 1")
+                .OrFailIf(true, "Error 2");
+
+            result.IsFailed.Should().BeTrue();
+            result.Errors.Select(s => s.Message)
+                .Should()
+                .BeEquivalentTo("Error 1");
+        }
+
+        [Fact]
+        public void Evaluates_if_the_previous_statement_has_succeeded()
+        {
+            var result = Result.FailIf(false, "Error 1")
+                .OrFailIf(true, "Error 2");
+
+            result.IsFailed.Should().BeTrue();
+            result.Errors.Select(s => s.Message)
+                .Should()
+                .BeEquivalentTo("Error 2");
+        }
+
+        [Fact]
+        public void Succeeds_if_all_statements_have_succeeded()
+        {
+            var result = Result.FailIf(false, "Error 1")
+                .OrFailIf(false, "Error 2");
+
+            result.IsSuccess.Should().BeTrue();
+        }
+    }
+}

--- a/src/FluentResults/Extensions/ResultExtensions.cs
+++ b/src/FluentResults/Extensions/ResultExtensions.cs
@@ -329,5 +329,22 @@ namespace FluentResults.Extensions
             var result = await resultTask;
             return result.ToResult(value);
         }
+        
+        /// <summary>
+        /// Create a success/failed result depending on the parameter isFailure
+        /// </summary>
+        /// <param name="source">The previous result</param>
+        /// <param name="isFailure">The condition to check if the result should fail</param>
+        /// <param name="error">The error message</param>
+        /// <returns>The previous result if it is already failed or a new result</returns>
+        public static Result OrFailIf(this Result source, bool isFailure, string error)
+        {
+            if (source.IsFailed)
+            {
+                return source;
+            }
+            
+            return isFailure ? Result.Fail(error) : source;
+        }
     }
 }


### PR DESCRIPTION
Hello there,

This pull request introduces a new extension method, `OrFailIf`, to the Result class.

I hope you don't mind that I went ahead and created this pull request directly. I felt a separate discussion wasn't necessary since this addition is minor, straightforward, and self-explanatory.

I often find myself needing to split `Result.Merge()` statements to provide more detailed error messages, particularly for null checks. To avoid repetitive code in every validation, I believe this feature offers a clean and effective solution to that problem.

Looking forward to your feedback!

Best regards,
Martin