### PR TITLE
Pin FluentAssertions dependency to prevent future updates

### DIFF
--- a/src/FluentResults.Extensions.FluentAssertions/FluentResults.Extensions.FluentAssertions.csproj
+++ b/src/FluentResults.Extensions.FluentAssertions/FluentResults.Extensions.FluentAssertions.csproj
@@ -26,7 +26,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.7.0" />
+    <PackageReference Include="FluentAssertions" Version="[6.7.0]" />
     <PackageReference Include="FluentResults" Version="3.0.0" />
   </ItemGroup>
 

--- a/src/FluentResults.Test/FluentResults.Test.csproj
+++ b/src/FluentResults.Test/FluentResults.Test.csproj
@@ -16,7 +16,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="6.7.0" />
+    <PackageReference Include="FluentAssertions" Version="[6.7.0]" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
FluentAssertions v8 is now paid for commercial use, package manager should prevent any updates so that FluentResults could be used commercially.

Next phase should probably be passing all dependencies to [Shouldly](https://github.com/shouldly/shouldly) ,
which is now sponsored by FluentAssertions old sponsors.

Closes #231 