### PR TITLE
Adjust Package references for .NET 8 and .NET 9 #238

### DIFF
--- a/src/FluentResults.Extensions.AspNetCore/FluentResults.Extensions.AspNetCore.csproj
+++ b/src/FluentResults.Extensions.AspNetCore/FluentResults.Extensions.AspNetCore.csproj
@@ -1,49 +1,49 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0;netstandard2.1;net8.0;net9.0</TargetFrameworks>
-		<PackageId>FluentResults.Extensions.AspNetCore</PackageId>
-		<Version>0.2.1.0</Version>
-		<Authors>Michael Altmann</Authors>
-		<Description>FluentResult Asp.Net Core integration</Description>
-		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-		<PackageLicenseExpression>MIT</PackageLicenseExpression>
-		<PackageReleaseNotes>
-			- CHANGED Microsoft.AspNetCore.Mvc.Core update to 2.3.0 (2.2.5 is deprecated) #233
-			- CHANGED Microsoft.AspNetCore.Mvc.Core package reference to Microsoft.AspNetCore.App framework reference for .NET8 and .NET9 #238
-		</PackageReleaseNotes>
-		<Copyright>Copyright 2022 (c) Michael Altmann. All rights reserved.</Copyright>
-		<PackageTags>Result Results exception error handling FluentResults</PackageTags>
-		<PackageProjectUrl>https://github.com/altmann/FluentResults</PackageProjectUrl>
-		<PackageIconUrl>https://raw.githubusercontent.com/altmann/FluentResults/master/resources/icons/FluentResults-Icon-128.png</PackageIconUrl>
-		<PackageIcon>FluentResults-Icon-128.png</PackageIcon>
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0;net9.0</TargetFrameworks>
+    <PackageId>FluentResults.Extensions.AspNetCore</PackageId>
+    <Version>0.2.1.0</Version>
+    <Authors>Michael Altmann</Authors>
+    <Description>FluentResult Asp.Net Core integration</Description>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageReleaseNotes>
+      - CHANGED Microsoft.AspNetCore.Mvc.Core update to 2.3.0 (2.2.5 is deprecated) #233
+      - CHANGED Microsoft.AspNetCore.Mvc.Core package reference to Microsoft.AspNetCore.App framework reference for .NET8 and .NET9 #238
+    </PackageReleaseNotes>
+    <Copyright>Copyright 2022 (c) Michael Altmann. All rights reserved.</Copyright>
+    <PackageTags>Result Results exception error handling FluentResults</PackageTags>
+    <PackageProjectUrl>https://github.com/altmann/FluentResults</PackageProjectUrl>
+    <PackageIconUrl>https://raw.githubusercontent.com/altmann/FluentResults/master/resources/icons/FluentResults-Icon-128.png</PackageIconUrl>
+    <PackageIcon>FluentResults-Icon-128.png</PackageIcon>
 
-		<!--SourceLink-->
-		<PublishRepositoryUrl>true</PublishRepositoryUrl>
-		<EmbedUntrackedSources>true</EmbedUntrackedSources>
-		<IncludeSymbols>true</IncludeSymbols>
-		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
-		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-	</PropertyGroup>
+    <!--SourceLink-->
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+  </PropertyGroup>
 
-	<PropertyGroup>
-		<UseFrameworkReference>$([MSBuild]::VersionGreaterThanOrEquals('$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)'))','8.0'))</UseFrameworkReference>
-	</PropertyGroup>
+  <PropertyGroup>
+    <UseFrameworkReference>$([MSBuild]::VersionGreaterThanOrEquals('$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)'))','8.0'))</UseFrameworkReference>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<PackageReference Include="FluentResults" Version="4.0.0" />
-	</ItemGroup>
-	
-	<ItemGroup Condition="$(UseFrameworkReference)" >
-		<FrameworkReference Include="Microsoft.AspNetCore.App" />
-	</ItemGroup>
-	
-	<ItemGroup Condition="!$(UseFrameworkReference)" >
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.3.0" />
-	</ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="FluentResults" Version="4.0.0" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<None Include="..\..\resources\icons\FluentResults-Icon-128.png" Pack="true" PackagePath="" />
-	</ItemGroup>
+  <ItemGroup Condition="$(UseFrameworkReference)" >
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup Condition="!$(UseFrameworkReference)" >
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.3.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\resources\icons\FluentResults-Icon-128.png" Pack="true" PackagePath="" />
+  </ItemGroup>
 
 </Project>

--- a/src/FluentResults.Extensions.AspNetCore/FluentResults.Extensions.AspNetCore.csproj
+++ b/src/FluentResults.Extensions.AspNetCore/FluentResults.Extensions.AspNetCore.csproj
@@ -1,37 +1,49 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0;net9.0</TargetFrameworks>
-    <PackageId>FluentResults.Extensions.AspNetCore</PackageId>
-    <Version>0.2.0.0</Version>
-    <Authors>Michael Altmann</Authors>
-    <Description>FluentResult Asp.Net Core integration</Description>
-    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageReleaseNotes>
-		- CHANGED Microsoft.AspNetCore.Mvc.Core update to 2.3.0 (2.2.5 is deprecated) #233
-    </PackageReleaseNotes>
-    <Copyright>Copyright 2025 (c) Michael Altmann. All rights reserved.</Copyright>
-    <PackageTags>Result Results exception error handling FluentResults</PackageTags>
-    <PackageProjectUrl>https://github.com/altmann/FluentResults</PackageProjectUrl>
-    <PackageIconUrl>https://raw.githubusercontent.com/altmann/FluentResults/master/resources/icons/FluentResults-Icon-128.png</PackageIconUrl>
-    <PackageIcon>FluentResults-Icon-128.png</PackageIcon>
+	<PropertyGroup>
+		<TargetFrameworks>netstandard2.0;netstandard2.1;net8.0;net9.0</TargetFrameworks>
+		<PackageId>FluentResults.Extensions.AspNetCore</PackageId>
+		<Version>0.2.1.0</Version>
+		<Authors>Michael Altmann</Authors>
+		<Description>FluentResult Asp.Net Core integration</Description>
+		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+		<PackageReleaseNotes>
+			- CHANGED Microsoft.AspNetCore.Mvc.Core update to 2.3.0 (2.2.5 is deprecated) #233
+			- CHANGED Microsoft.AspNetCore.Mvc.Core package reference to Microsoft.AspNetCore.App framework reference for .NET8 and .NET9 #238
+		</PackageReleaseNotes>
+		<Copyright>Copyright 2022 (c) Michael Altmann. All rights reserved.</Copyright>
+		<PackageTags>Result Results exception error handling FluentResults</PackageTags>
+		<PackageProjectUrl>https://github.com/altmann/FluentResults</PackageProjectUrl>
+		<PackageIconUrl>https://raw.githubusercontent.com/altmann/FluentResults/master/resources/icons/FluentResults-Icon-128.png</PackageIconUrl>
+		<PackageIcon>FluentResults-Icon-128.png</PackageIcon>
 
-    <!--SourceLink-->
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-  </PropertyGroup>
-    
-  <ItemGroup>
-    <PackageReference Include="FluentResults" Version="4.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.3.0" />
-  </ItemGroup>
+		<!--SourceLink-->
+		<PublishRepositoryUrl>true</PublishRepositoryUrl>
+		<EmbedUntrackedSources>true</EmbedUntrackedSources>
+		<IncludeSymbols>true</IncludeSymbols>
+		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
+		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <None Include="..\..\resources\icons\FluentResults-Icon-128.png" Pack="true" PackagePath="" />
-  </ItemGroup>
+	<PropertyGroup>
+		<UseFrameworkReference>$([MSBuild]::VersionGreaterThanOrEquals('$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)'))','8.0'))</UseFrameworkReference>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="FluentResults" Version="4.0.0" />
+	</ItemGroup>
+	
+	<ItemGroup Condition="$(UseFrameworkReference)" >
+		<FrameworkReference Include="Microsoft.AspNetCore.App" />
+	</ItemGroup>
+	
+	<ItemGroup Condition="!$(UseFrameworkReference)" >
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.3.0" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<None Include="..\..\resources\icons\FluentResults-Icon-128.png" Pack="true" PackagePath="" />
+	</ItemGroup>
 
 </Project>

--- a/src/FluentResults/FluentResults.csproj
+++ b/src/FluentResults/FluentResults.csproj
@@ -2,22 +2,23 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0;net9.0</TargetFrameworks>
     <PackageId>FluentResults</PackageId>
-    <Version>4.0.0.0</Version>
+    <Version>4.0.1.0</Version>
     <Authors>Michael Altmann</Authors>
     <Description>A lightweight Result object implementation for .NET</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReleaseNotes>
-	    - CHANGED Introduce ReadOnlyList type #164
-	    - CHANGED Deconstruct operators (BREAKING CHANGE) #217
-	    - CHANGED Calling Fail methods with an empty error list throws exception #227
+		- CHANGED Introduce ReadOnlyList type #164
+		- CHANGED Deconstruct operators (BREAKING CHANGE) #217
+		- CHANGED Calling Fail methods with an empty error list throws exception #227
 		- ADDED FailIf methods accepting a collection of errors #213
 		- ADDED Enumerable support for Merge #215
 		- ADDED OrFailIf method #221
-        - ADDED .NET8 and .NET9 support 
+		- ADDED .NET8 and .NET9 support
 		- FIXED readme #225 #228 #229 #230
-    </PackageReleaseNotes>
-    <Copyright>Copyright 2025 (c) Michael Altmann. All rights reserved.</Copyright>
+		- FIXED PackageReferences for .NET8 and .NET9 #238
+	</PackageReleaseNotes>
+    <Copyright>Copyright 2024 (c) Michael Altmann. All rights reserved.</Copyright>
     <PackageTags>Result Results exception error handling</PackageTags>
     <PackageProjectUrl>https://github.com/altmann/FluentResults</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/altmann/FluentResults/master/resources/icons/FluentResults-Icon-128.png</PackageIconUrl>
@@ -33,6 +34,10 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <UseFrameworkReference>$([MSBuild]::VersionGreaterThanOrEquals('$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)'))','8.0'))</UseFrameworkReference>
+  </PropertyGroup>
+    
   <ItemGroup>
     <None Include="..\..\resources\icons\FluentResults-Icon-128.png" Pack="true" PackagePath="" />
   </ItemGroup>
@@ -42,8 +47,19 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup Condition="!$(UseFrameworkReference)">
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.1" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
   </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
+  </ItemGroup>
+	
+  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.7" />
+  </ItemGroup>	
 </Project>


### PR DESCRIPTION
Resolves issue #238 

Switching Package references for ``Microsoft.AspNetCore.Mvc.Core`` to FrameworkReference ``Microsoft.AspNetCore.App`` for .NET 8 and .NET 9

Updating Microsoft packages to .NET 8 and .NET 9 to same major version