### PR TITLE
Fix typo in contributors section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -675,7 +675,7 @@ I love this project but implementing features, answering issues or maintaining c
 
 ## Contributors
 
-Thanks to all the contributers and to all the people who gave feedback!
+Thanks to all the contributors and to all the people who gave feedback!
 
 <a href="https://github.com/altmann/fluentresults/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=altmann/fluentresults" />


### PR DESCRIPTION
This pull request makes a minor correction to the `README.md` file, fixing a typo in the word "contributers"